### PR TITLE
Set up Vite build and modern React structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SEEPEP Sports Tracker</title>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body>
     <div id="root"></div>
-    <script type="text/babel" src="app.js"></script>
+    <script type="module" src="/src/app.jsx"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "murray-bridge-high-school-2025-sepep",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.1.0",
+    "@vitejs/plugin-react": "^4.2.0"
+  }
+}

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1,8 +1,6 @@
-// Adapted for direct browser execution (no bundler).
-// Removed ES module import/export; relying on global React & ReactDOM from UMD scripts in index.html.
-// NOTE: If you later move to a build setup, reintroduce: import React from 'react'; export default App;
+import React, { useEffect, useMemo, useState, useCallback } from "react";
+import ReactDOM from "react-dom/client";
 
-const { useEffect, useMemo, useState, useCallback } = React;
 
 /************************************************************
  * SEEPEP Fixture & Results Tracker (Browser Version)
@@ -438,7 +436,7 @@ function AdminView({ division, data, onImportJSON, onPushAll }) {
 
 // ========================= Main App =========================
 const YEARS = ["2025", "2024", "2023"];
-function App() {
+export default function App() {
   const [division, setDivision] = useState(YEARS[0]);
   const [loading, setLoading] = useState({ type: null, message: "" });
   const [toast, setToast] = useState({ message: "", type: "success" });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});


### PR DESCRIPTION
## Summary
- Initialize package.json with React, React DOM, and Vite tooling
- Move legacy app.js into src/app.jsx using ES modules and a Vite config
- Replace CDN scripts in index.html with a module entry point

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*
- `npm run build` *(fails: vite not found)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ff91f4a483249830bc86a1e1c61d