### PR TITLE
feat: add mock API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# SEEPEP Fixture & Results Tracker
+
+This project is a small React application used for managing fixtures and results.  
+A lightweight mock server is provided so contributors can develop and test the
+frontend without needing access to the production Google Apps Script endpoint.
+
+## Mock API Server
+
+The mock server stores all data in memory and implements the same actions as the
+real backend: `readAll`, `upsertTeam`, `upsertFixture`, `upsertResult` and
+`deleteFixtureRemote`.
+
+### Running the server
+
+```bash
+npm start
+```
+
+This serves the app and API at `http://localhost:3001`.
+
+### Using the mock server from the frontend
+
+Open the application with the `?mock=1` flag to switch the frontend to the mock
+API:
+
+```
+http://localhost:3001/?mock=1
+```
+
+Alternatively set `window.__SEEPEP_USE_MOCK__ = true` before loading `app.js`.
+Omitting the flag (or setting it to `false`) will use the real production API.
+
+The mock server keeps data only in memory, so restarting it clears all stored
+teams, fixtures and results.

--- a/app.js
+++ b/app.js
@@ -9,7 +9,10 @@ const { useEffect, useMemo, useState, useCallback } = React;
  ************************************************************/
 
 // ========================= Backend Config =========================
-const API = (window.__SEEPEP_API__ ?? "https://script.google.com/macros/s/AKfycbxQF1jPP2EjOt8RH81onVHgxazq1uxzZpQ7WBt214pcsV7IkXLzxxS72uwNJQoy7n2F/exec");
+const USE_MOCK_SERVER = Boolean(window.__SEEPEP_USE_MOCK__ || new URLSearchParams(window.location.search).has('mock'));
+const API = USE_MOCK_SERVER
+  ? "/api"
+  : (window.__SEEPEP_API__ ?? "https://script.google.com/macros/s/AKfycbxQF1jPP2EjOt8RH81onVHgxazq1uxzZpQ7WBt214pcsV7IkXLzxxS72uwNJQoy7n2F/exec");
 const TOKEN = (window.__SEEPEP_TOKEN__ ?? "");
 
 // ========================= Validation =========================

--- a/index.html
+++ b/index.html
@@ -11,6 +11,10 @@
 </head>
 <body>
     <div id="root"></div>
+    <script>
+        // Set to true to use the local mock API server
+        // window.__SEEPEP_USE_MOCK__ = true;
+    </script>
     <script type="text/babel" src="app.js"></script>
 </body>
 </html>

--- a/mock-server.js
+++ b/mock-server.js
@@ -1,0 +1,68 @@
+const express = require('express');
+const cors = require('cors');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+app.use(cors());
+app.use(express.json());
+
+// In-memory data store
+const db = { teams: [], fixtures: [], results: [] };
+
+function uid() {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+// API routes
+app.get('/api', (req, res) => {
+  const { action } = req.query;
+  if (action === 'readAll') {
+    return res.json(db);
+  }
+  return res.status(400).json({ error: 'Unknown action' });
+});
+
+app.post('/api', (req, res) => {
+  const { action } = req.body;
+  switch (action) {
+    case 'upsertTeam': {
+      const team = req.body.team || {};
+      if (!team.id) team.id = uid();
+      const idx = db.teams.findIndex(t => t.id === team.id);
+      if (idx >= 0) db.teams[idx] = team; else db.teams.push(team);
+      return res.json({ team });
+    }
+    case 'upsertFixture': {
+      const fixture = req.body.fixture || {};
+      if (!fixture.id) fixture.id = uid();
+      const idx = db.fixtures.findIndex(f => f.id === fixture.id);
+      if (idx >= 0) db.fixtures[idx] = fixture; else db.fixtures.push(fixture);
+      return res.json({ fixture });
+    }
+    case 'upsertResult': {
+      const result = req.body.result || {};
+      if (!result.id) result.id = uid();
+      const idx = db.results.findIndex(r => r.id === result.id);
+      if (idx >= 0) db.results[idx] = result; else db.results.push(result);
+      return res.json({ result });
+    }
+    case 'deleteFixtureRemote': {
+      const { id } = req.body;
+      db.fixtures = db.fixtures.filter(f => f.id !== id);
+      db.results = db.results.filter(r => r.id !== id);
+      return res.json({ success: true });
+    }
+    default:
+      return res.status(400).json({ error: 'Unknown action' });
+  }
+});
+
+// Serve static files
+app.use(express.static(path.join(__dirname)));
+
+app.listen(PORT, () => {
+  console.log(`Mock server running at http://localhost:${PORT}`);
+  console.log('Open http://localhost:' + PORT + '/?mock=1 to use it.');
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "murray-bridge-high-school-2025-sepep",
+  "version": "1.0.0",
+  "description": "SEEPEP fixture & results tracker",
+  "main": "mock-server.js",
+  "scripts": {
+    "start": "node mock-server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add in-memory Express mock server with readAll and upsert endpoints
- allow frontend to switch between production and mock server via flag
- document usage and provide sample configuration in index.html

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cors)*
- `node mock-server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68c1ff96719c83248b2e5b05a9411e81