### PR TITLE
fix(ladder): compute standings using matches from all rounds

### DIFF
--- a/src/pages/Ladder.jsx
+++ b/src/pages/Ladder.jsx
@@ -7,7 +7,7 @@ export default function Ladder() {
   useEffect(() => {
     async function load() {
       const teams = (await getTeams())[0]?.teams || [];
-      const fixtures = (await getFixtures())[0]?.matches || [];
+      const fixtures = (await getFixtures()).flatMap(r => r?.matches || []);
       const results = (await getResults()).results || [];
       setRows(computeLadder(teams, fixtures, results));
     }


### PR DESCRIPTION
## Summary
- flatten fixtures from every round before computing ladder standings

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2c4f22cd88324a93607979d8a70b7