### PR TITLE
fix: enforce light theme text color

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="color-scheme" content="light dark">
+  <meta name="color-scheme" content="light">
   <title>SEPEP Sports Tracker</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/vanilla@0.3.0/dist/elements.umd.min.js"></script>
 </head>
-<body>
+<body class="bg-white text-gray-900">
   <div id="root"></div>
   <script type="module" src="/src/main.jsx"></script>
 </body>


### PR DESCRIPTION
## Summary
- ensure site renders with readable dark text by forcing light color scheme
- set default body classes for white background and dark text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2c5a7f0648324a79b6df316ce3d59