### PR TITLE
feat: integrate tailwindcss with vanilla plugin

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="color-scheme" content="light">
   <title>SEPEP Sports Tracker</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/vanilla@0.3.0/dist/elements.umd.min.js"></script>
 </head>
 <body class="bg-white text-gray-900">
   <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,11 @@
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.2.0",
-        "vite": "^5.1.0"
+        "vite": "^5.1.0",
+        "tailwindcss": "^3.4.4",
+        "postcss": "^8.4.38",
+        "autoprefixer": "^10.4.16",
+        "@tailwindcss/vanilla": "^0.3.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
   },
   "devDependencies": {
     "vite": "^5.1.0",
-    "@vitejs/plugin-react": "^4.2.0"
+    "@vitejs/plugin-react": "^4.2.0",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.38",
+    "autoprefixer": "^10.4.16",
+    "@tailwindcss/vanilla": "^0.3.0"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import './index.css';
 import App from './App.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,19 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        pocket: {
+          light: "#f3f5f7",
+          DEFAULT: "#ef4056",
+          dark: "#d6243e"
+        }
+      },
+      fontFamily: {
+        sans: ["Inter", "sans-serif"]
+      }
+    }
+  },
+  plugins: [require("@tailwindcss/vanilla")]
+};


### PR DESCRIPTION
## Summary
- add Tailwind CSS, PostCSS, Autoprefixer and vanilla plugin config
- wire up Tailwind styles via `index.css`
- drop CDN scripts and rely on local build pipeline

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'tailwindcss')*


------
https://chatgpt.com/codex/tasks/task_e_68c2ca252b788324a49b822c3f4351d1