### PR TITLE
style: enhance navigation layout

### DIFF
--- a/src/components/Nav/AppSidebar.jsx
+++ b/src/components/Nav/AppSidebar.jsx
@@ -13,15 +13,26 @@ const links = [
 
 export default function AppSidebar({ current, navigate, open, onClose }) {
   return (
-    <div className={`${open ? 'block' : 'hidden'} md:block fixed md:relative inset-0 z-40`}>
-      <div className="absolute inset-0 bg-black/50 md:hidden" onClick={onClose}></div>
-      <nav className="absolute md:relative bg-white w-64 h-full p-4 space-y-2 overflow-y-auto">
-        {links.map(l => (
-          <button key={l.id} onClick={() => { navigate(l.id); onClose(); }} className={`block w-full text-left px-2 py-1 rounded ${current === l.id ? 'bg-blue-100' : 'hover:bg-blue-50'}`}>
-            {l.label}
-          </button>
-        ))}
-      </nav>
+    <div className={`drawer z-40 ${open ? 'drawer-open' : ''} md:drawer-open`}>
+      <input id="app-sidebar-drawer" type="checkbox" className="drawer-toggle" checked={open} readOnly />
+      <div className="drawer-content"></div>
+      <div className="drawer-side">
+        <label htmlFor="app-sidebar-drawer" className="drawer-overlay" onClick={onClose}></label>
+        <nav className="w-64 min-h-full bg-white/90 backdrop-blur shadow-lg rounded-r-xl p-4 space-y-2">
+          {links.map(l => (
+            <button
+              key={l.id}
+              onClick={() => {
+                navigate(l.id);
+                onClose();
+              }}
+              className={`block w-full text-left rounded-lg px-4 py-2 text-sm font-medium hover:bg-indigo-50 ${current === l.id ? 'bg-indigo-100' : ''}`}
+            >
+              {l.label}
+            </button>
+          ))}
+        </nav>
+      </div>
     </div>
   );
 }

--- a/src/components/Nav/AppTopbar.jsx
+++ b/src/components/Nav/AppTopbar.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function AppTopbar({ onMenu, teacherMode, toggleTeacher }) {
   return (
-    <header className="flex items-center justify-between bg-blue-600 text-white px-4 py-2">
+    <header className="sticky top-0 z-50 flex items-center justify-between bg-gradient-to-r from-indigo-500 to-purple-500 text-white shadow-sm rounded-b-xl px-6 py-4">
       <button className="md:hidden" onClick={onMenu} aria-label="Open menu">
         <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />


### PR DESCRIPTION
## Summary
- Add sticky gradient topbar with rounded bottom and increased padding
- Replace custom sidebar with responsive drawer using Tailwind classes
- Improve sidebar link styling with hover states and translucent backdrop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2d05314f88324b7517707eea8c3a3