### PR TITLE
feat: improve dashboard and unify page layouts

### DIFF
--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -11,9 +11,13 @@ export default function Admin() {
     a.click();
   }
   return (
-    <div>
-      <h2 className="text-2xl font-semibold mb-4">Admin</h2>
-      <button className="px-3 py-2 bg-blue-600 text-white rounded" onClick={exportData}>Export Results JSON</button>
-    </div>
+    <section className="max-w-5xl mx-auto py-10 space-y-6">
+      <h2 className="text-3xl font-semibold tracking-tight">Admin</h2>
+      <div className="bg-white shadow-sm rounded-xl p-6">
+        <button className="px-3 py-2 bg-blue-600 text-white rounded" onClick={exportData}>
+          Export Results JSON
+        </button>
+      </div>
+    </section>
   );
 }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -3,8 +3,34 @@ import React from 'react';
 export default function Dashboard() {
   return (
     <div>
-      <h2 className="text-2xl font-semibold mb-4">Dashboard</h2>
-      <p className="text-sm text-slate-600">Welcome to the SEPEP Tournament Hub.</p>
+      <section className="text-center py-20 bg-gradient-to-b from-white to-indigo-50">
+        <h1 className="text-4xl font-bold mb-4">SEPEP Tournament Hub</h1>
+        <p className="text-slate-600 mb-8">Welcome to the central dashboard.</p>
+        <div className="mx-auto max-w-4xl rounded-xl shadow-lg overflow-hidden">
+          <img
+            src="https://via.placeholder.com/800x400"
+            alt="Dashboard preview"
+            className="w-full"
+          />
+        </div>
+      </section>
+
+      <section className="max-w-5xl mx-auto py-10">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          <div className="bg-white shadow-sm rounded-xl p-6">
+            <h3 className="text-lg font-medium mb-2">Fixtures</h3>
+            <p className="text-sm text-slate-600">Upcoming matches and results.</p>
+          </div>
+          <div className="bg-white shadow-sm rounded-xl p-6">
+            <h3 className="text-lg font-medium mb-2">Teams</h3>
+            <p className="text-sm text-slate-600">Profiles for every team.</p>
+          </div>
+          <div className="bg-white shadow-sm rounded-xl p-6">
+            <h3 className="text-lg font-medium mb-2">Ladder</h3>
+            <p className="text-sm text-slate-600">Current standings and points.</p>
+          </div>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/pages/Fixtures.jsx
+++ b/src/pages/Fixtures.jsx
@@ -7,18 +7,20 @@ export default function Fixtures() {
     getFixtures().then(setRounds);
   }, []);
   return (
-    <div>
-      <h2 className="text-2xl font-semibold mb-4">Fixtures & Results</h2>
-      {rounds.map(r => (
-        <div key={r.round} className="mb-4">
-          <h3 className="font-medium">Round {r.round} - {r.date}</h3>
-          <ul className="ml-4 list-disc">
-            {r.matches.map(m => (
-              <li key={m.id}>{m.home} vs {m.away} @ {m.venue} {m.time}</li>
-            ))}
-          </ul>
-        </div>
-      ))}
-    </div>
+    <section className="max-w-5xl mx-auto py-10 space-y-6">
+      <h2 className="text-3xl font-semibold tracking-tight">Fixtures & Results</h2>
+      <div className="bg-white shadow-sm rounded-xl p-6 space-y-4">
+        {rounds.map(r => (
+          <div key={r.round} className="">
+            <h3 className="font-medium">Round {r.round} - {r.date}</h3>
+            <ul className="ml-4 list-disc">
+              {r.matches.map(m => (
+                <li key={m.id}>{m.home} vs {m.away} @ {m.venue} {m.time}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
   );
 }

--- a/src/pages/Ladder.jsx
+++ b/src/pages/Ladder.jsx
@@ -14,38 +14,40 @@ export default function Ladder() {
     load();
   }, []);
   return (
-    <div>
-      <h2 className="text-2xl font-semibold mb-4">Ladder / Standings</h2>
-      <table className="min-w-full text-sm">
-        <thead>
-          <tr className="text-left border-b">
-            <th className="p-2">Team</th>
-            <th className="p-2">GP</th>
-            <th className="p-2">W</th>
-            <th className="p-2">L</th>
-            <th className="p-2">D</th>
-            <th className="p-2">PF</th>
-            <th className="p-2">PA</th>
-            <th className="p-2">Pts</th>
-            <th className="p-2">%</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map(r => (
-            <tr key={r.teamId} className="border-b">
-              <td className="p-2">{r.name}</td>
-              <td className="p-2">{r.GP}</td>
-              <td className="p-2">{r.W}</td>
-              <td className="p-2">{r.L}</td>
-              <td className="p-2">{r.D}</td>
-              <td className="p-2">{r.PF}</td>
-              <td className="p-2">{r.PA}</td>
-              <td className="p-2">{r.Pts}</td>
-              <td className="p-2">{r['%']}</td>
+    <section className="max-w-5xl mx-auto py-10 space-y-6">
+      <h2 className="text-3xl font-semibold tracking-tight">Ladder / Standings</h2>
+      <div className="bg-white shadow-sm rounded-xl p-6 overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left border-b">
+              <th className="p-2">Team</th>
+              <th className="p-2">GP</th>
+              <th className="p-2">W</th>
+              <th className="p-2">L</th>
+              <th className="p-2">D</th>
+              <th className="p-2">PF</th>
+              <th className="p-2">PA</th>
+              <th className="p-2">Pts</th>
+              <th className="p-2">%</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+          </thead>
+          <tbody>
+            {rows.map(r => (
+              <tr key={r.teamId} className="border-b">
+                <td className="p-2">{r.name}</td>
+                <td className="p-2">{r.GP}</td>
+                <td className="p-2">{r.W}</td>
+                <td className="p-2">{r.L}</td>
+                <td className="p-2">{r.D}</td>
+                <td className="p-2">{r.PF}</td>
+                <td className="p-2">{r.PA}</td>
+                <td className="p-2">{r.Pts}</td>
+                <td className="p-2">{r['%']}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
   );
 }

--- a/src/pages/MVP.jsx
+++ b/src/pages/MVP.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 export default function MVP() {
   return (
-    <div>
-      <h2 className="text-2xl font-semibold mb-4">MVP & Fair-Play</h2>
-      <p className="text-sm text-slate-600">Vote tracking coming soon.</p>
-    </div>
+    <section className="max-w-5xl mx-auto py-10 space-y-6">
+      <h2 className="text-3xl font-semibold tracking-tight">MVP & Fair-Play</h2>
+      <div className="bg-white shadow-sm rounded-xl p-6">
+        <p className="text-sm text-slate-600">Vote tracking coming soon.</p>
+      </div>
+    </section>
   );
 }

--- a/src/pages/News.jsx
+++ b/src/pages/News.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 export default function News() {
   return (
-    <div>
-      <h2 className="text-2xl font-semibold mb-4">Announcements & Media</h2>
-      <p className="text-sm text-slate-600">No announcements yet.</p>
-    </div>
+    <section className="max-w-5xl mx-auto py-10 space-y-6">
+      <h2 className="text-3xl font-semibold tracking-tight">Announcements & Media</h2>
+      <div className="bg-white shadow-sm rounded-xl p-6">
+        <p className="text-sm text-slate-600">No announcements yet.</p>
+      </div>
+    </section>
   );
 }

--- a/src/pages/Stats.jsx
+++ b/src/pages/Stats.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 export default function Stats() {
   return (
-    <div>
-      <h2 className="text-2xl font-semibold mb-4">Stats</h2>
-      <p className="text-sm text-slate-600">Statistics coming soon.</p>
-    </div>
+    <section className="max-w-5xl mx-auto py-10 space-y-6">
+      <h2 className="text-3xl font-semibold tracking-tight">Stats</h2>
+      <div className="bg-white shadow-sm rounded-xl p-6">
+        <p className="text-sm text-slate-600">Statistics coming soon.</p>
+      </div>
+    </section>
   );
 }

--- a/src/pages/Teams.jsx
+++ b/src/pages/Teams.jsx
@@ -5,18 +5,20 @@ export default function Teams() {
   const [divisions, setDivisions] = useState([]);
   useEffect(() => { getTeams().then(setDivisions); }, []);
   return (
-    <div>
-      <h2 className="text-2xl font-semibold mb-4">Teams & Profiles</h2>
-      {divisions.map(d => (
-        <div key={d.id} className="mb-4">
-          <h3 className="font-medium">{d.name}</h3>
-          <ul className="ml-4 list-disc">
-            {d.teams.map(t => (
-              <li key={t.id}>{t.name} - Coach {t.coach}</li>
-            ))}
-          </ul>
-        </div>
-      ))}
-    </div>
+    <section className="max-w-5xl mx-auto py-10 space-y-6">
+      <h2 className="text-3xl font-semibold tracking-tight">Teams & Profiles</h2>
+      <div className="bg-white shadow-sm rounded-xl p-6 space-y-4">
+        {divisions.map(d => (
+          <div key={d.id} className="">
+            <h3 className="font-medium">{d.name}</h3>
+            <ul className="ml-4 list-disc">
+              {d.teams.map(t => (
+                <li key={t.id}>{t.name} - Coach {t.coach}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary
- Add gradient hero section with placeholder image and feature cards to the dashboard
- Standardize layout across Fixtures, Teams, Ladder, Stats, MVP, News, and Admin pages with centered sections and card containers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2d15d4a248324bc2956171d1ffcd0