### PR TITLE
Remove nonexistent Tailwind plugin causing npm 404

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,7 @@
         "vite": "^5.1.0",
         "tailwindcss": "^3.4.4",
         "postcss": "^8.4.38",
-        "autoprefixer": "^10.4.16",
-        "@tailwindcss/vanilla": "^0.3.0"
+        "autoprefixer": "^10.4.16"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@vitejs/plugin-react": "^4.2.0",
     "tailwindcss": "^3.4.4",
     "postcss": "^8.4.38",
-    "autoprefixer": "^10.4.16",
-    "@tailwindcss/vanilla": "^0.3.0"
+    "autoprefixer": "^10.4.16"
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,5 +15,5 @@ export default {
       }
     }
   },
-  plugins: [require("@tailwindcss/vanilla")]
+  plugins: []
 };


### PR DESCRIPTION
## Summary
- remove @tailwindcss/vanilla plugin dependency that does not exist
- clear plugin reference from Tailwind configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c32f06582c8324ac61cccf4cc4b700