### PR TITLE
build(elements): wire Tailwind Plus Elements via npm (registry fix)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@tailwindplus:registry=https://registry.npmjs.org/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ React + Tailwind demo for managing school sports tournaments.
 npm install
 ```
 
+### UI Elements
+
+Tailwind Plus Elements are sourced from npm (`@tailwindplus/elements`) using the npm registry. If installing via npm isn't possible, they can be loaded from the CDN:
+
+```html
+<script type="module" src="https://cdn.jsdelivr.net/npm/@tailwindplus/elements@1"></script>
+```
+
 ## Development
 
 ```bash

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 </head>
 <body class="bg-white text-gray-900">
   <div id="root"></div>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@tailwindplus/elements@1"></script>
   <script type="module" src="/src/main.jsx"></script>
 </body>
 </html>

--- a/src/components/Nav/AppSidebar.jsx
+++ b/src/components/Nav/AppSidebar.jsx
@@ -13,26 +13,21 @@ const links = [
 
 export default function AppSidebar({ current, navigate, open, onClose }) {
   return (
-    <div className={`drawer z-40 ${open ? 'drawer-open' : ''} md:drawer-open`}>
-      <input id="app-sidebar-drawer" type="checkbox" className="drawer-toggle" checked={open} readOnly />
-      <div className="drawer-content"></div>
-      <div className="drawer-side">
-        <label htmlFor="app-sidebar-drawer" className="drawer-overlay" onClick={onClose}></label>
-        <nav className="w-64 min-h-full bg-white/90 backdrop-blur shadow-lg rounded-r-xl p-4 space-y-2">
-          {links.map(l => (
-            <button
-              key={l.id}
-              onClick={() => {
-                navigate(l.id);
-                onClose();
-              }}
-              className={`block w-full text-left rounded-lg px-4 py-2 text-sm font-medium hover:bg-indigo-50 ${current === l.id ? 'bg-indigo-100' : ''}`}
-            >
-              {l.label}
-            </button>
-          ))}
-        </nav>
-      </div>
-    </div>
+    <el-drawer id="app-sidebar-drawer" open={open} onClose={onClose} className="z-40 md:open">
+      <el-menu className="w-64 min-h-full bg-white/90 backdrop-blur shadow-lg rounded-r-xl p-4 space-y-2">
+        {links.map(l => (
+          <button
+            key={l.id}
+            onClick={() => {
+              navigate(l.id);
+              onClose();
+            }}
+            className={`block w-full text-left rounded-lg px-4 py-2 text-sm font-medium hover:bg-indigo-50 ${current == l.id ? 'bg-indigo-100' : ''}`}
+          >
+            {l.label}
+          </button>
+        ))}
+      </el-menu>
+    </el-drawer>
   );
 }


### PR DESCRIPTION
## Summary
- add npm scope registry for Tailwind Plus
- load Tailwind Plus Elements from CDN and integrate drawer menu component
- document Elements usage and CDN fallback

## Testing
- `npm test`
- `npm run build` *(fails: vite not found, packages could not be installed due to registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c33162fd388324af9e6f997ea7b741