### PR TITLE
feat: add points difference to ladder

### DIFF
--- a/src/lib/ladder.js
+++ b/src/lib/ladder.js
@@ -8,6 +8,7 @@ export function computeLadder(teams, fixtures, results) {
     D: 0,
     PF: 0,
     PA: 0,
+    PD: 0,
     Pts: 0,
     '%': 0
   }));
@@ -27,6 +28,7 @@ export function computeLadder(teams, fixtures, results) {
   });
   stats.forEach(s => {
     s['%'] = s.PA ? Number(((s.PF / s.PA) * 100).toFixed(2)) : 0;
+    s.PD = s.PF - s.PA;
   });
-  return stats.sort((a,b) => b.Pts - a.Pts || b['%'] - a['%']);
+  return stats.sort((a,b) => b.Pts - a.Pts || b.PD - a.PD || b['%'] - a['%']);
 }

--- a/src/lib/ladder.test.js
+++ b/src/lib/ladder.test.js
@@ -7,15 +7,18 @@ const teams = [
 ];
 
 const fixtures = [
-  { id: 'R1M1', home: 'A01', away: 'A02' }
+  { id: 'R1M1', home: 'A01', away: 'A02' },
+  { id: 'R2M1', home: 'A02', away: 'A01' }
 ];
 
 const results = [
-  { matchId: 'R1M1', homeScore: 10, awayScore: 8 }
+  { matchId: 'R1M1', homeScore: 10, awayScore: 8 },
+  { matchId: 'R2M1', homeScore: 12, awayScore: 6 }
 ];
 
 const ladder = computeLadder(teams, fixtures, results);
-assert.strictEqual(ladder[0].teamId, 'A01');
-assert.strictEqual(ladder[0].W, 1);
-assert.strictEqual(ladder[1].L, 1);
+assert.strictEqual(ladder[0].teamId, 'A02');
+assert.strictEqual(ladder[0].PD, 4);
+assert.strictEqual(ladder[1].PD, -4);
+assert.strictEqual(ladder[0].Pts, ladder[1].Pts);
 console.log('ladder tests passed');


### PR DESCRIPTION
## Summary
- add point difference (PD) to ladder stats and use as secondary tiebreaker
- expand ladder unit test to verify PD and sorting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c337e556a08324942d9e6937819987