### PR TITLE
feat: add fixture upload

### DIFF
--- a/src/lib/dataApi.js
+++ b/src/lib/dataApi.js
@@ -14,6 +14,8 @@ export async function getTeams() {
 }
 
 export async function getFixtures() {
+  const stored = localStorage.getItem('fixtures');
+  if (stored) return JSON.parse(stored);
   const data = await fetchJSON('/data/fixtures.json');
   return data.rounds ?? [];
 }
@@ -35,4 +37,9 @@ export function upsertResult(result) {
 export async function getFixturesByRound(round) {
   const rounds = await getFixtures();
   return rounds.find(r => r.round === round);
+}
+
+export function saveFixtures(rounds) {
+  localStorage.setItem('fixtures', JSON.stringify(rounds));
+  return rounds;
 }

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getResults } from '../lib/dataApi.js';
+import { getResults, saveFixtures } from '../lib/dataApi.js';
 
 export default function Admin() {
   async function exportData() {
@@ -10,13 +10,34 @@ export default function Admin() {
     a.download = 'results.json';
     a.click();
   }
+
+  function importFixtures(e) {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = evt => {
+      try {
+        const json = JSON.parse(evt.target.result);
+        const rounds = json.rounds ?? [];
+        saveFixtures(rounds);
+        alert('Fixtures uploaded');
+      } catch (err) {
+        alert('Invalid fixtures file');
+      }
+    };
+    reader.readAsText(file);
+  }
   return (
     <section className="max-w-5xl mx-auto py-10 space-y-6">
       <h2 className="text-3xl font-semibold tracking-tight">Admin</h2>
-      <div className="bg-white shadow-sm rounded-xl p-6">
+      <div className="bg-white shadow-sm rounded-xl p-6 space-y-4">
         <button className="px-3 py-2 bg-blue-600 text-white rounded" onClick={exportData}>
           Export Results JSON
         </button>
+        <div>
+          <label className="block mb-2 font-medium">Upload Fixtures JSON</label>
+          <input type="file" accept="application/json" onChange={importFixtures} />
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- allow fixtures to be stored in localStorage and saved via API helper
- add Admin upload control to import fixtures from a JSON sheet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c338440c7883248480492060905d9d