### PR TITLE
style(sepep): Pocket UI refresh (anchors preserved)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="color-scheme" content="light">
   <title>SEPEP Sports Tracker</title>
+  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+  <style type="text/tailwindcss">
+    @theme {
+      --color-accent: var(--color-indigo-500);
+    }
+  </style>
 </head>
-<body class="bg-white text-gray-900">
+<body class="bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-200">
   <div id="root"></div>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@tailwindplus/elements@1"></script>
   <script type="module" src="/src/main.jsx"></script>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,11 @@ export default function App() {
   const [view, setView] = useState('dashboard');
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [teacherMode, setTeacherMode] = useState(() => localStorage.getItem('teacherMode') === '1');
+  const [darkMode, setDarkMode] = useState(() => localStorage.getItem('darkMode') === '1');
+  useEffect(() => {
+    if (darkMode) document.documentElement.classList.add('dark');
+    else document.documentElement.classList.remove('dark');
+  }, [darkMode]);
   useEffect(() => {
     function onHash() {
       const v = window.location.hash.replace('#', '');
@@ -44,18 +49,21 @@ export default function App() {
     setTeacherMode(next);
     localStorage.setItem('teacherMode', next ? '1' : '0');
   }
+  function toggleDark() {
+    const next = !darkMode;
+    setDarkMode(next);
+    localStorage.setItem('darkMode', next ? '1' : '0');
+  }
   return (
-    <div className="min-h-screen bg-gradient-to-b from-indigo-50 to-white">
-      <div className="h-screen flex overflow-hidden">
-        <AppSidebar current={view} navigate={navigate} open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-        <div className="flex-1 flex flex-col">
-          <AppTopbar onMenu={() => setSidebarOpen(true)} teacherMode={teacherMode} toggleTeacher={toggleTeacher} />
-          <main className="flex-1 overflow-y-auto">
-            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-12">
-              <Current teacherMode={teacherMode} />
-            </div>
-          </main>
-        </div>
+    <div className="min-h-screen bg-white dark:bg-slate-900">
+      <AppSidebar current={view} navigate={navigate} open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+      <div className="min-h-screen flex flex-col">
+        <AppTopbar onMenu={() => setSidebarOpen(true)} teacherMode={teacherMode} toggleTeacher={toggleTeacher} darkMode={darkMode} toggleDark={toggleDark} />
+        <main className="flex-1 py-8 sm:py-10 lg:py-14">
+          <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 leading-7 text-slate-600 dark:text-slate-300">
+            <Current teacherMode={teacherMode} />
+          </div>
+        </main>
       </div>
     </div>
   );

--- a/src/components/Nav/AppSidebar.jsx
+++ b/src/components/Nav/AppSidebar.jsx
@@ -14,7 +14,7 @@ const links = [
 export default function AppSidebar({ current, navigate, open, onClose }) {
   return (
     <el-drawer id="app-sidebar-drawer" open={open} onClose={onClose} className="z-40 md:open">
-      <el-menu className="w-64 min-h-full bg-white/90 backdrop-blur shadow-lg rounded-r-xl p-4 space-y-2">
+      <el-menu className="w-64 min-h-full bg-white/80 dark:bg-slate-900/70 backdrop-blur border-r border-slate-200/60 dark:border-slate-800 p-4 space-y-2">
         {links.map(l => (
           <button
             key={l.id}
@@ -22,7 +22,7 @@ export default function AppSidebar({ current, navigate, open, onClose }) {
               navigate(l.id);
               onClose();
             }}
-            className={`block w-full text-left rounded-lg px-4 py-2 text-sm font-medium hover:bg-indigo-50 ${current == l.id ? 'bg-indigo-100' : ''}`}
+            className={`block w-full text-left rounded-lg px-4 py-2 text-sm font-medium hover:bg-slate-50/70 dark:hover:bg-slate-800/50 transition ${current == l.id ? 'bg-slate-100 dark:bg-slate-800/40' : ''}`}
           >
             {l.label}
           </button>

--- a/src/components/Nav/AppTopbar.jsx
+++ b/src/components/Nav/AppTopbar.jsx
@@ -1,17 +1,40 @@
 import React from 'react';
 
-export default function AppTopbar({ onMenu, teacherMode, toggleTeacher }) {
+export default function AppTopbar({ onMenu, teacherMode, toggleTeacher, darkMode, toggleDark }) {
   return (
-    <header className="sticky top-0 z-50 flex items-center justify-between bg-gradient-to-r from-indigo-500 to-purple-500 text-white shadow-sm rounded-b-xl px-6 py-4">
-      <button className="md:hidden" onClick={onMenu} aria-label="Open menu">
-        <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-      </button>
-      <h1 className="font-semibold">SEPEP Tournament Hub</h1>
-      <button onClick={toggleTeacher} className="text-sm bg-white/10 px-2 py-1 rounded" aria-label="Toggle teacher mode">
-        {teacherMode ? 'Teacher Mode' : 'Student Mode'}
-      </button>
+    <header className="sticky top-0 z-40 bg-white/70 dark:bg-slate-900/70 backdrop-blur border-b border-slate-200/60 dark:border-slate-800">
+      <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 h-14 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <button className="md:hidden" onClick={onMenu} aria-label="Open menu">
+            <svg className="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 5.25h16.5m-16.5 6h16.5m-16.5 6h16.5" />
+            </svg>
+          </button>
+          <a href="#dashboard" className="font-semibold text-slate-900 dark:text-white">SEPEP Tournament Hub</a>
+        </div>
+        <nav className="hidden md:flex items-center gap-6 text-sm font-medium">
+          <a href="#fixtures" className="text-slate-700 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white">Fixtures</a>
+          <a href="#ladder" className="text-slate-700 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white">Ladder</a>
+          <a href="#teams" className="text-slate-700 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white">Teams</a>
+          <a href="#news" className="text-slate-700 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white">News</a>
+        </nav>
+        <div className="flex items-center gap-2">
+          <button onClick={toggleTeacher} className="hidden sm:inline-flex items-center gap-2 rounded-xl ring-1 ring-slate-300/60 bg-white px-4 py-2 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-200 dark:ring-white/10 text-sm" aria-label="Toggle teacher mode">
+            {teacherMode ? 'Teacher' : 'Student'}
+          </button>
+          <button onClick={toggleDark} className="inline-flex items-center gap-2 rounded-xl ring-1 ring-slate-300/60 bg-white px-2 py-2 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-200 dark:ring-white/10" aria-label="Toggle dark mode">
+            {darkMode ? (
+              <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M21.752 15.002A9 9 0 1112.999 3.25a7.5 7.5 0 008.753 11.752z" />
+              </svg>
+            ) : (
+              <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364 1.386-1.591 1.591M21 12h-2.25m-1.386 6.364-1.591-1.591M12 18.75V21m-6.364-1.386 1.591-1.591M3 12h2.25m1.386-6.364 1.591 1.591M12 8.25a3.75 3.75 0 100 7.5 3.75 3.75 0 000-7.5z" />
+              </svg>
+            )}
+          </button>
+        </div>
+      </div>
     </header>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,0 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import './index.css';
 import App from './App.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -28,15 +28,15 @@ export default function Admin() {
     reader.readAsText(file);
   }
   return (
-    <section className="max-w-5xl mx-auto py-10 space-y-6">
-      <h2 className="text-3xl font-semibold tracking-tight">Admin</h2>
-      <div className="bg-white shadow-sm rounded-xl p-6 space-y-4">
-        <button className="px-3 py-2 bg-blue-600 text-white rounded" onClick={exportData}>
+    <section id="admin" className="py-8 sm:py-10 lg:py-14">
+      <h2 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">Admin</h2>
+      <div className="mt-6 rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-slate-900/60 dark:ring-white/10 p-5 sm:p-6 space-y-4">
+        <button className="inline-flex items-center gap-2 rounded-xl bg-slate-900 text-white px-4 py-2 hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900" onClick={exportData}>
           Export Results JSON
         </button>
-        <div>
-          <label className="block mb-2 font-medium">Upload Fixtures JSON</label>
-          <input type="file" accept="application/json" onChange={importFixtures} />
+        <div className="space-y-2">
+          <label className="block font-medium text-slate-900 dark:text-slate-200">Upload Fixtures JSON</label>
+          <input className="block w-full rounded-xl border-slate-300/60 bg-white/80 dark:bg-slate-900/60 px-3 py-2 focus:ring-2 focus:ring-slate-900/20 outline-none" type="file" accept="application/json" onChange={importFixtures} />
         </div>
       </div>
     </section>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -3,10 +3,10 @@ import React from 'react';
 export default function Dashboard() {
   return (
     <div>
-      <section className="text-center py-20 bg-gradient-to-b from-white to-indigo-50">
-        <h1 className="text-4xl font-bold mb-4">SEPEP Tournament Hub</h1>
-        <p className="text-slate-600 mb-8">Welcome to the central dashboard.</p>
-        <div className="mx-auto max-w-4xl rounded-xl shadow-lg overflow-hidden">
+      <section id="dashboard" className="py-8 sm:py-10 lg:py-14 text-center">
+        <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white mb-4">SEPEP Tournament Hub</h1>
+        <p className="text-slate-600 dark:text-slate-300 mb-8 leading-7">Welcome to the central dashboard.</p>
+        <div className="mx-auto max-w-4xl rounded-2xl ring-1 ring-black/5 overflow-hidden">
           <img
             src="https://via.placeholder.com/800x400"
             alt="Dashboard preview"
@@ -15,19 +15,19 @@ export default function Dashboard() {
         </div>
       </section>
 
-      <section className="max-w-5xl mx-auto py-10">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-          <div className="bg-white shadow-sm rounded-xl p-6">
-            <h3 className="text-lg font-medium mb-2">Fixtures</h3>
-            <p className="text-sm text-slate-600">Upcoming matches and results.</p>
+      <section className="py-8 sm:py-10 lg:py-14 border-t border-slate-200/60 dark:border-slate-800">
+        <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-1 md:grid-cols-3 gap-5">
+          <div className="rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-slate-900/60 dark:ring-white/10 p-5 sm:p-6">
+            <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-2">Fixtures</h3>
+            <p className="text-sm text-slate-600 dark:text-slate-300 leading-7">Upcoming matches and results.</p>
           </div>
-          <div className="bg-white shadow-sm rounded-xl p-6">
-            <h3 className="text-lg font-medium mb-2">Teams</h3>
-            <p className="text-sm text-slate-600">Profiles for every team.</p>
+          <div className="rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-slate-900/60 dark:ring-white/10 p-5 sm:p-6">
+            <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-2">Teams</h3>
+            <p className="text-sm text-slate-600 dark:text-slate-300 leading-7">Profiles for every team.</p>
           </div>
-          <div className="bg-white shadow-sm rounded-xl p-6">
-            <h3 className="text-lg font-medium mb-2">Ladder</h3>
-            <p className="text-sm text-slate-600">Current standings and points.</p>
+          <div className="rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-slate-900/60 dark:ring-white/10 p-5 sm:p-6">
+            <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-2">Ladder</h3>
+            <p className="text-sm text-slate-600 dark:text-slate-300 leading-7">Current standings and points.</p>
           </div>
         </div>
       </section>

--- a/src/pages/Fixtures.jsx
+++ b/src/pages/Fixtures.jsx
@@ -7,15 +7,21 @@ export default function Fixtures() {
     getFixtures().then(setRounds);
   }, []);
   return (
-    <section className="max-w-5xl mx-auto py-10 space-y-6">
-      <h2 className="text-3xl font-semibold tracking-tight">Fixtures & Results</h2>
-      <div className="bg-white shadow-sm rounded-xl p-6 space-y-4">
+    <section id="fixtures" className="py-8 sm:py-10 lg:py-14">
+      <h2 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">Fixtures & Results</h2>
+      <div className="mt-6 space-y-6">
         {rounds.map(r => (
-          <div key={r.round} className="">
-            <h3 className="font-medium">Round {r.round} - {r.date}</h3>
-            <ul className="ml-4 list-disc">
+          <div key={r.round} className="rounded-2xl overflow-hidden ring-1 ring-black/5">
+            <div className="px-4 py-2 bg-slate-50/80 dark:bg-slate-800/40 text-slate-500 uppercase text-xs tracking-wide">Round {r.round} – {r.date}</div>
+            <ul className="divide-y divide-slate-200/60 dark:divide-slate-800">
               {r.matches.map(m => (
-                <li key={m.id}>{m.home} vs {m.away} @ {m.venue} {m.time}</li>
+                <li key={m.id} className="p-4 flex items-center justify-between">
+                  <span className="font-medium text-slate-900 dark:text-slate-100">{m.home} vs {m.away}</span>
+                  <span className="flex items-center gap-2 text-sm text-slate-500">
+                    {m.venue} {m.time}
+                    <span className="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ring-1 bg-slate-50 text-slate-900 ring-slate-200">Scheduled</span>
+                  </span>
+                </li>
               ))}
             </ul>
           </div>

--- a/src/pages/Ladder.jsx
+++ b/src/pages/Ladder.jsx
@@ -14,35 +14,35 @@ export default function Ladder() {
     load();
   }, []);
   return (
-    <section className="max-w-5xl mx-auto py-10 space-y-6">
-      <h2 className="text-3xl font-semibold tracking-tight">Ladder / Standings</h2>
-      <div className="bg-white shadow-sm rounded-xl p-6 overflow-x-auto">
-        <table className="min-w-full text-sm">
+    <section id="ladder" className="py-8 sm:py-10 lg:py-14">
+      <h2 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">Ladder / Standings</h2>
+      <div className="mt-6 rounded-2xl ring-1 ring-black/5 overflow-x-auto">
+        <table className="w-full text-sm">
           <thead>
-            <tr className="text-left border-b">
-              <th className="p-2">Team</th>
-              <th className="p-2">GP</th>
-              <th className="p-2">W</th>
-              <th className="p-2">L</th>
-              <th className="p-2">D</th>
-              <th className="p-2">PF</th>
-              <th className="p-2">PA</th>
-              <th className="p-2">Pts</th>
-              <th className="p-2">%</th>
+            <tr className="bg-slate-50/80 dark:bg-slate-800/40 text-slate-500 uppercase text-xs tracking-wide">
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-200">Team</th>
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-200">GP</th>
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-200">W</th>
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-200">L</th>
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-200">D</th>
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-200">PF</th>
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-200">PA</th>
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-200">Pts</th>
+              <th className="px-3 py-2 text-left font-semibold text-slate-700 dark:text-slate-200">%</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody className="divide-y divide-slate-200/60 dark:divide-slate-800">
             {rows.map(r => (
-              <tr key={r.teamId} className="border-b">
-                <td className="p-2">{r.name}</td>
-                <td className="p-2">{r.GP}</td>
-                <td className="p-2">{r.W}</td>
-                <td className="p-2">{r.L}</td>
-                <td className="p-2">{r.D}</td>
-                <td className="p-2">{r.PF}</td>
-                <td className="p-2">{r.PA}</td>
-                <td className="p-2">{r.Pts}</td>
-                <td className="p-2">{r['%']}</td>
+              <tr key={r.teamId} className="hover:bg-slate-50/70 dark:hover:bg-slate-800/50 transition">
+                <td className="px-3 py-2 text-slate-600 dark:text-slate-300">{r.name}</td>
+                <td className="px-3 py-2 text-slate-600 dark:text-slate-300">{r.GP}</td>
+                <td className="px-3 py-2 text-slate-600 dark:text-slate-300">{r.W}</td>
+                <td className="px-3 py-2 text-slate-600 dark:text-slate-300">{r.L}</td>
+                <td className="px-3 py-2 text-slate-600 dark:text-slate-300">{r.D}</td>
+                <td className="px-3 py-2 text-slate-600 dark:text-slate-300">{r.PF}</td>
+                <td className="px-3 py-2 text-slate-600 dark:text-slate-300">{r.PA}</td>
+                <td className="px-3 py-2 text-slate-600 dark:text-slate-300">{r.Pts}</td>
+                <td className="px-3 py-2 text-slate-600 dark:text-slate-300">{r['%']}</td>
               </tr>
             ))}
           </tbody>

--- a/src/pages/MVP.jsx
+++ b/src/pages/MVP.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 export default function MVP() {
   return (
-    <section className="max-w-5xl mx-auto py-10 space-y-6">
-      <h2 className="text-3xl font-semibold tracking-tight">MVP & Fair-Play</h2>
-      <div className="bg-white shadow-sm rounded-xl p-6">
-        <p className="text-sm text-slate-600">Vote tracking coming soon.</p>
+    <section id="mvp" className="py-8 sm:py-10 lg:py-14">
+      <h2 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">MVP & Fair-Play</h2>
+      <div className="mt-6 rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-slate-900/60 dark:ring-white/10 p-5 sm:p-6">
+        <p className="text-sm leading-7 text-slate-600 dark:text-slate-300">Vote tracking coming soon.</p>
       </div>
     </section>
   );

--- a/src/pages/News.jsx
+++ b/src/pages/News.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 export default function News() {
   return (
-    <section className="max-w-5xl mx-auto py-10 space-y-6">
-      <h2 className="text-3xl font-semibold tracking-tight">Announcements & Media</h2>
-      <div className="bg-white shadow-sm rounded-xl p-6">
-        <p className="text-sm text-slate-600">No announcements yet.</p>
+    <section id="news" className="py-8 sm:py-10 lg:py-14">
+      <h2 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">Announcements & Media</h2>
+      <div className="mt-6 rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-slate-900/60 dark:ring-white/10 p-5 sm:p-6">
+        <p className="text-sm leading-7 text-slate-600 dark:text-slate-300">No announcements yet.</p>
       </div>
     </section>
   );

--- a/src/pages/Stats.jsx
+++ b/src/pages/Stats.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 export default function Stats() {
   return (
-    <section className="max-w-5xl mx-auto py-10 space-y-6">
-      <h2 className="text-3xl font-semibold tracking-tight">Stats</h2>
-      <div className="bg-white shadow-sm rounded-xl p-6">
-        <p className="text-sm text-slate-600">Statistics coming soon.</p>
+    <section id="stats" className="py-8 sm:py-10 lg:py-14">
+      <h2 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">Stats</h2>
+      <div className="mt-6 rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-slate-900/60 dark:ring-white/10 p-5 sm:p-6">
+        <p className="text-sm leading-7 text-slate-600 dark:text-slate-300">Statistics coming soon.</p>
       </div>
     </section>
   );

--- a/src/pages/Teams.jsx
+++ b/src/pages/Teams.jsx
@@ -5,17 +5,20 @@ export default function Teams() {
   const [divisions, setDivisions] = useState([]);
   useEffect(() => { getTeams().then(setDivisions); }, []);
   return (
-    <section className="max-w-5xl mx-auto py-10 space-y-6">
-      <h2 className="text-3xl font-semibold tracking-tight">Teams & Profiles</h2>
-      <div className="bg-white shadow-sm rounded-xl p-6 space-y-4">
+    <section id="teams" className="py-8 sm:py-10 lg:py-14">
+      <h2 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">Teams & Profiles</h2>
+      <div className="mt-6 space-y-10">
         {divisions.map(d => (
-          <div key={d.id} className="">
-            <h3 className="font-medium">{d.name}</h3>
-            <ul className="ml-4 list-disc">
+          <div key={d.id} className="space-y-4">
+            <h3 className="text-xl font-semibold text-slate-900 dark:text-white">{d.name}</h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
               {d.teams.map(t => (
-                <li key={t.id}>{t.name} - Coach {t.coach}</li>
+                <div key={t.id} className="rounded-2xl ring-1 ring-black/5 p-5 bg-white/80 dark:bg-slate-900/60">
+                  <div className="font-medium text-slate-900 dark:text-slate-100">{t.name}</div>
+                  <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">Coach {t.coach}</div>
+                </div>
               ))}
-            </ul>
+            </div>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- upgrade to Tailwind v4 Play CDN and apply Pocket theme
- add sticky header with hash-based navigation, dark mode toggle, and teacher mode button
- restyle fixtures, ladder, teams, and admin sections with accessible Pocket cards
- drop placeholder screenshots to avoid committing binary assets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c339829b3c8324b04a5405604fd982