### PR TITLE
style(sepep): Pocket UI refresh (anchors preserved)

### DIFF
--- a/src/components/Nav/AppTopbar.jsx
+++ b/src/components/Nav/AppTopbar.jsx
@@ -19,7 +19,7 @@ export default function AppTopbar({ onMenu, teacherMode, toggleTeacher, darkMode
           <a href="#news" className="text-slate-700 hover:text-accent dark:text-slate-300 dark:hover:text-accent">News</a>
         </nav>
         <div className="flex items-center gap-2">
-          <button onClick={toggleTeacher} className="hidden sm:inline-flex items-center gap-2 rounded-xl ring-1 ring-accent/30 bg-white/80 px-4 py-2 hover:bg-accent/10 dark:bg-slate-800 dark:text-slate-200 dark:ring-accent/30 text-sm" aria-label="Toggle teacher mode">
+          <button onClick={toggleTeacher} className="inline-flex items-center gap-2 rounded-xl ring-1 ring-accent/30 bg-white/80 px-4 py-2 hover:bg-accent/10 dark:bg-slate-800 dark:text-slate-200 dark:ring-accent/30 text-sm" aria-label="Toggle teacher mode">
             {teacherMode ? 'Teacher' : 'Student'}
           </button>
           <button onClick={toggleDark} className="inline-flex items-center gap-2 rounded-xl ring-1 ring-accent/30 bg-white/80 px-2 py-2 hover:bg-accent/10 dark:bg-slate-800 dark:text-slate-200 dark:ring-accent/30" aria-label="Toggle dark mode">


### PR DESCRIPTION
## Summary
- ensure teacher mode toggle remains visible on small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c342cf686c8324a83b3be68ac9110c