### PR TITLE
feat: display team players with modal

### DIFF
--- a/data/players.json
+++ b/data/players.json
@@ -1,0 +1,12 @@
+{
+  "players": [
+    {"id":"A01-1","team":"A01","name":"Alice Smith","photo":"","bio":"Captain and leading scorer."},
+    {"id":"A01-2","team":"A01","name":"Beth Jones","photo":"","bio":"Aggressive defender."},
+    {"id":"A01-3","team":"A01","name":"Cara Lee","photo":"","bio":"Midfielder with great vision."},
+    {"id":"A01-4","team":"A01","name":"Dana Liu","photo":"","bio":"Reliable goalkeeper."},
+    {"id":"A01-5","team":"A01","name":"Eva Moore","photo":"","bio":"Young talent on the rise."},
+    {"id":"A01-6","team":"A01","name":"Faye Kim","photo":"","bio":"Speedy winger."},
+    {"id":"A01-7","team":"A01","name":"Gia Singh","photo":"","bio":"Utility player who can cover many roles."},
+    {"id":"A01-8","team":"A01","name":"Hana Patel","photo":"","bio":"Defensive stalwart."}
+  ]
+}

--- a/public/data/players.json
+++ b/public/data/players.json
@@ -1,0 +1,12 @@
+{
+  "players": [
+    {"id":"A01-1","team":"A01","name":"Alice Smith","photo":"","bio":"Captain and leading scorer."},
+    {"id":"A01-2","team":"A01","name":"Beth Jones","photo":"","bio":"Aggressive defender."},
+    {"id":"A01-3","team":"A01","name":"Cara Lee","photo":"","bio":"Midfielder with great vision."},
+    {"id":"A01-4","team":"A01","name":"Dana Liu","photo":"","bio":"Reliable goalkeeper."},
+    {"id":"A01-5","team":"A01","name":"Eva Moore","photo":"","bio":"Young talent on the rise."},
+    {"id":"A01-6","team":"A01","name":"Faye Kim","photo":"","bio":"Speedy winger."},
+    {"id":"A01-7","team":"A01","name":"Gia Singh","photo":"","bio":"Utility player who can cover many roles."},
+    {"id":"A01-8","team":"A01","name":"Hana Patel","photo":"","bio":"Defensive stalwart."}
+  ]
+}

--- a/src/lib/dataApi.js
+++ b/src/lib/dataApi.js
@@ -25,6 +25,19 @@ export async function getTeams() {
     const data = await fetchJSON('/data/teams.json');
     cache.teams = data.divisions ?? [];
   }
+
+  // attach players to each team
+  try {
+    const players = await getPlayers();
+    cache.teams.forEach(div => {
+      (div.teams || []).forEach(team => {
+        team.players = players.filter(p => p.team === team.id);
+      });
+    });
+  } catch {
+    // ignore player errors; teams will simply have empty player lists
+  }
+
   return cache.teams;
 }
 

--- a/src/pages/Teams.jsx
+++ b/src/pages/Teams.jsx
@@ -1,9 +1,23 @@
 import React, { useEffect, useState } from 'react';
 import { getTeams } from '../lib/dataApi.js';
 
+function initials(name = '') {
+  return name
+    .split(' ')
+    .map(n => n[0] || '')
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+}
+
 export default function Teams() {
   const [divisions, setDivisions] = useState([]);
-  useEffect(() => { getTeams().then(setDivisions); }, []);
+  const [selected, setSelected] = useState(null);
+
+  useEffect(() => {
+    getTeams().then(setDivisions);
+  }, []);
+
   return (
     <section id="teams" className="py-8 sm:py-10 lg:py-14">
       <h2 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">Teams & Profiles</h2>
@@ -16,12 +30,65 @@ export default function Teams() {
                 <div key={t.id} className="rounded-2xl ring-1 ring-black/5 p-5 bg-white/80 dark:bg-slate-900/60">
                   <div className="font-medium text-slate-900 dark:text-slate-100">{t.name}</div>
                   <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">Coach {t.coach}</div>
+                  {t.players && t.players.length > 0 && (
+                    <div className="mt-4 flex -space-x-2 overflow-hidden">
+                      {t.players.slice(0, 6).map(p => (
+                        <button
+                          key={p.id}
+                          type="button"
+                          onClick={() => setSelected(p)}
+                          className="relative inline-block rounded-full ring-2 ring-white"
+                        >
+                          {p.photo ? (
+                            <img
+                              src={p.photo}
+                              alt={p.name}
+                              className="h-8 w-8 rounded-full object-cover"
+                            />
+                          ) : (
+                              <span className="h-8 w-8 rounded-full bg-slate-300 flex items-center justify-center text-xs font-medium text-slate-700">
+                              {initials(p.name)}
+                            </span>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  )}
                 </div>
               ))}
             </div>
           </div>
         ))}
       </div>
+
+      {selected && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="relative bg-white dark:bg-slate-800 rounded-lg p-6 max-w-sm w-full">
+            <button
+              type="button"
+              className="absolute top-2 right-2 text-slate-500 hover:text-slate-700"
+              onClick={() => setSelected(null)}
+            >
+              ×
+            </button>
+            {selected.photo && (
+              <img
+                src={selected.photo}
+                alt={selected.name}
+                className="w-24 h-24 rounded-full object-cover mx-auto"
+              />
+            )}
+            <h3 className="mt-4 text-xl font-semibold text-center text-slate-900 dark:text-white">
+              {selected.name}
+            </h3>
+            {selected.bio && (
+              <p className="mt-2 text-sm text-slate-600 dark:text-slate-300 text-center">
+                {selected.bio}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- attach player lists to teams via new `getPlayers`
- show up to six player avatars per team and modal with bio on click
- add sample `players.json` for offline data

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c354ebc19c8324a36193402081ce9a