### PR TITLE
refactor: unify button styles

### DIFF
--- a/src/components/Nav/AppTopbar.jsx
+++ b/src/components/Nav/AppTopbar.jsx
@@ -5,7 +5,11 @@ export default function AppTopbar({ onMenu, teacherMode, toggleTeacher, darkMode
     <header className="sticky top-0 z-40 bg-white/70 dark:bg-slate-900/70 backdrop-blur border-b border-slate-200/60 dark:border-slate-800">
       <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 h-14 flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <button className="md:hidden" onClick={onMenu} aria-label="Open menu">
+          <button
+            className="md:hidden inline-flex items-center gap-2 rounded-xl ring-1 ring-slate-300/60 bg-white p-2 hover:bg-slate-50 dark:bg-slate-900 dark:text-slate-200 dark:ring-white/10"
+            onClick={onMenu}
+            aria-label="Open menu"
+          >
             <svg className="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 5.25h16.5m-16.5 6h16.5m-16.5 6h16.5" />
             </svg>
@@ -19,10 +23,18 @@ export default function AppTopbar({ onMenu, teacherMode, toggleTeacher, darkMode
           <a href="#news" className="text-slate-700 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white">News</a>
         </nav>
         <div className="flex items-center gap-2">
-          <button onClick={toggleTeacher} className="hidden sm:inline-flex items-center gap-2 rounded-xl ring-1 ring-slate-300/60 bg-white px-4 py-2 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-200 dark:ring-white/10 text-sm" aria-label="Toggle teacher mode">
+          <button
+            onClick={toggleTeacher}
+            className="hidden sm:inline-flex items-center gap-2 rounded-xl ring-1 ring-slate-300/60 bg-white px-4 py-2 hover:bg-slate-50 dark:bg-slate-900 dark:text-slate-200 dark:ring-white/10 text-sm"
+            aria-label="Toggle teacher mode"
+          >
             {teacherMode ? 'Teacher' : 'Student'}
           </button>
-          <button onClick={toggleDark} className="inline-flex items-center gap-2 rounded-xl ring-1 ring-slate-300/60 bg-white px-2 py-2 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-200 dark:ring-white/10" aria-label="Toggle dark mode">
+          <button
+            onClick={toggleDark}
+            className="inline-flex items-center gap-2 rounded-xl ring-1 ring-slate-300/60 bg-white p-2 hover:bg-slate-50 dark:bg-slate-900 dark:text-slate-200 dark:ring-white/10"
+            aria-label="Toggle dark mode"
+          >
             {darkMode ? (
               <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M21.752 15.002A9 9 0 1112.999 3.25a7.5 7.5 0 008.753 11.752z" />

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -31,7 +31,10 @@ export default function Admin() {
     <section id="admin" className="py-8 sm:py-10 lg:py-14">
       <h2 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">Admin</h2>
       <div className="mt-6 rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-slate-900/60 dark:ring-white/10 p-5 sm:p-6 space-y-4">
-        <button className="inline-flex items-center gap-2 rounded-xl bg-slate-900 text-white px-4 py-2 hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900" onClick={exportData}>
+        <button
+          className="inline-flex items-center gap-2 rounded-xl bg-brand-600 text-white px-4 py-2 hover:bg-brand-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-700"
+          onClick={exportData}
+        >
           Export Results JSON
         </button>
         <div className="space-y-2">

--- a/src/pages/Teams.jsx
+++ b/src/pages/Teams.jsx
@@ -37,16 +37,16 @@ export default function Teams() {
                           key={p.id}
                           type="button"
                           onClick={() => setSelected(p)}
-                          className="relative inline-block rounded-full ring-2 ring-white"
+                          className="relative inline-flex items-center justify-center p-2 rounded-full"
                         >
                           {p.photo ? (
                             <img
                               src={p.photo}
                               alt={p.name}
-                              className="h-8 w-8 rounded-full object-cover"
+                              className="h-8 w-8 rounded-full object-cover ring-2 ring-white"
                             />
                           ) : (
-                              <span className="h-8 w-8 rounded-full bg-slate-300 flex items-center justify-center text-xs font-medium text-slate-700">
+                            <span className="h-8 w-8 rounded-full bg-slate-300 flex items-center justify-center text-xs font-medium text-slate-700 ring-2 ring-white">
                               {initials(p.name)}
                             </span>
                           )}
@@ -66,7 +66,7 @@ export default function Teams() {
           <div className="relative bg-white dark:bg-slate-800 rounded-lg p-6 max-w-sm w-full">
             <button
               type="button"
-              className="absolute top-2 right-2 text-slate-500 hover:text-slate-700"
+              className="absolute top-2 right-2 inline-flex items-center justify-center p-2 rounded-xl text-slate-500 hover:text-slate-700"
               onClick={() => setSelected(null)}
             >
               ×


### PR DESCRIPTION
## Summary
- apply new secondary styles and add padding for icon-only buttons in top bar
- update admin export button to primary brand styling
- ensure team profile buttons meet touch target guidelines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c356767ab88324b9583f481991f0b2