### PR TITLE
feat: add admin refresh workflow and form links

### DIFF
--- a/src/lib/dataApi.js
+++ b/src/lib/dataApi.js
@@ -120,5 +120,5 @@ export async function refreshAll() {
   localStorage.removeItem('fixtures');
   localStorage.removeItem('results');
   localStorage.removeItem('players');
-  await Promise.all([getTeams(), getFixtures(), getResults(), getPlayers()]);
+  await Promise.all([getTeams(), getFixtures(), getResults()]);
 }

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getResults, saveFixtures } from '../lib/dataApi.js';
+import { getResults, saveFixtures, refreshAll } from '../lib/dataApi.js';
 
 export default function Admin() {
   async function exportData() {
@@ -27,10 +27,42 @@ export default function Admin() {
     };
     reader.readAsText(file);
   }
+
+  async function handleRefresh() {
+    await refreshAll();
+    alert('Data refreshed');
+  }
   return (
     <section id="admin" className="py-8 sm:py-10 lg:py-14">
       <h2 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">Admin</h2>
       <div className="mt-6 rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-slate-900/60 dark:ring-white/10 p-5 sm:p-6 space-y-4">
+        <p className="rounded-xl bg-brand-50 p-4 text-sm text-slate-700 dark:bg-brand-400/10 dark:text-slate-200">
+          Use the forms below to submit updates. After submitting a form, click <em>Refresh Data</em> to reload the latest information.
+        </p>
+        <div className="flex flex-wrap gap-4">
+          <a
+            href="https://forms.gle/PLACEHOLDER_RESULTS"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-xl bg-brand-600 text-white px-4 py-2 hover:bg-brand-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-700"
+          >
+            Results Form
+          </a>
+          <a
+            href="https://forms.gle/PLACEHOLDER_FIXTURES"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-xl bg-brand-600 text-white px-4 py-2 hover:bg-brand-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-700"
+          >
+            Fixtures Form
+          </a>
+          <button
+            className="inline-flex items-center gap-2 rounded-xl bg-brand-600 text-white px-4 py-2 hover:bg-brand-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-700"
+            onClick={handleRefresh}
+          >
+            Refresh Data
+          </button>
+        </div>
         <button
           className="inline-flex items-center gap-2 rounded-xl bg-brand-600 text-white px-4 py-2 hover:bg-brand-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-700"
           onClick={exportData}


### PR DESCRIPTION
## Summary
- add refreshAll to data API to clear cache and reload teams, fixtures and results
- enhance Admin page with informational banner, Google Form links and a refresh button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c35fc659308324844712ce1b88e3c0