### PR TITLE
Remove top-left buttons from landing page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,7 +23,6 @@ const views = {
 
 export default function App() {
   const [view, setView] = useState('dashboard');
-  const [sidebarOpen, setSidebarOpen] = useState(false);
   const [teacherMode, setTeacherMode] = useState(() => localStorage.getItem('teacherMode') === '1');
   const [darkMode, setDarkMode] = useState(() => localStorage.getItem('darkMode') === '1');
   useEffect(() => {
@@ -60,9 +59,9 @@ export default function App() {
   }
   return (
     <div className="min-h-screen bg-white dark:bg-slate-900">
-      <AppSidebar current={view} navigate={navigate} open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+      <AppSidebar current={view} navigate={navigate} />
       <div className="min-h-screen flex flex-col">
-        <AppTopbar onMenu={() => setSidebarOpen(true)} teacherMode={teacherMode} toggleTeacher={toggleTeacher} darkMode={darkMode} toggleDark={toggleDark} />
+        <AppTopbar teacherMode={teacherMode} toggleTeacher={toggleTeacher} darkMode={darkMode} toggleDark={toggleDark} />
         <main className="flex-1 py-8 sm:py-10 lg:py-14">
           <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 leading-7 text-slate-600 dark:text-slate-300">
             <Current teacherMode={teacherMode} />

--- a/src/components/Nav/AppSidebar.jsx
+++ b/src/components/Nav/AppSidebar.jsx
@@ -11,19 +11,16 @@ const links = [
   { id: 'admin', label: 'Admin' }
 ];
 
-export default function AppSidebar({ current, navigate, open, onClose }) {
+export default function AppSidebar({ current, navigate }) {
   return (
-    <el-drawer id="app-sidebar-drawer" open={open} onClose={onClose} className="z-40 md:open">
+    <el-drawer id="app-sidebar-drawer" className="z-40 md:open">
       <el-menu className="w-64 min-h-full bg-white/80 dark:bg-slate-900/70 backdrop-blur border-r border-slate-200/60 dark:border-slate-800 p-4 space-y-2">
         {links.map(l => (
-          <button
-            key={l.id}
-            onClick={() => {
-              navigate(l.id);
-              onClose();
-            }}
-            className={`block w-full text-left rounded-lg px-4 py-2 text-sm font-medium hover:bg-slate-50/70 dark:hover:bg-slate-800/50 transition ${current == l.id ? 'bg-slate-100 dark:bg-slate-800/40' : ''}`}
-          >
+            <button
+              key={l.id}
+              onClick={() => navigate(l.id)}
+              className={`block w-full text-left rounded-lg px-4 py-2 text-sm font-medium hover:bg-slate-50/70 dark:hover:bg-slate-800/50 transition ${current == l.id ? 'bg-slate-100 dark:bg-slate-800/40' : ''}`}
+            >
             {l.label}
           </button>
         ))}

--- a/src/components/Nav/AppTopbar.jsx
+++ b/src/components/Nav/AppTopbar.jsx
@@ -1,20 +1,11 @@
 import React from 'react';
 
-export default function AppTopbar({ onMenu, teacherMode, toggleTeacher, darkMode, toggleDark }) {
+export default function AppTopbar({ teacherMode, toggleTeacher, darkMode, toggleDark }) {
   return (
     <header className="sticky top-0 z-40 bg-white/70 dark:bg-slate-900/70 backdrop-blur border-b border-slate-200/60 dark:border-slate-800">
       <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 h-14 flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <button
-            className="md:hidden inline-flex items-center gap-2 rounded-xl ring-1 ring-slate-300/60 bg-white p-2 hover:bg-slate-50 dark:bg-slate-900 dark:text-slate-200 dark:ring-white/10"
-            onClick={onMenu}
-            aria-label="Open menu"
-          >
-            <svg className="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 5.25h16.5m-16.5 6h16.5m-16.5 6h16.5" />
-            </svg>
-          </button>
-          <a href="#dashboard" className="font-semibold text-slate-900 dark:text-white">SEPEP Tournament Hub</a>
+        <div className="flex items-center">
+          <span className="font-semibold text-slate-900 dark:text-white">SEPEP Tournament Hub</span>
         </div>
         <nav className="hidden md:flex items-center gap-6 text-sm font-medium">
           <a href="#fixtures" className="text-slate-700 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white">Fixtures</a>


### PR DESCRIPTION
## Summary
- Remove hamburger menu and link from top bar, leaving a static title
- Simplify sidebar component and application layout after removing menu toggle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c39ce33c2c8324b32b509c5f2d69ab