### PR TITLE
feat: support configurable API base

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE=https://script.google.com/macros/s/APP_SCRIPT_ID/exec

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ npm run dev
 npm run build
 ```
 
+## Environment Variables
+
+Set `VITE_API_BASE` to control the base URL used for data API requests. Define it in a `.env` file:
+
+```bash
+VITE_API_BASE=https://script.google.com/macros/s/APP_SCRIPT_ID/exec
+```
+
+If unset, the application falls back to a placeholder URL. See `.env.example` for a template.
+
 ## Data schema
 
 Sample JSON files live in `public/data`:

--- a/src/lib/dataApi.js
+++ b/src/lib/dataApi.js
@@ -1,4 +1,4 @@
-const BASE = "https://script.google.com/macros/s/APP_SCRIPT_ID/exec";
+const BASE = import.meta.env.VITE_API_BASE || "https://script.google.com/macros/s/APP_SCRIPT_ID/exec";
 
 function noCache() {
   return `&_=${Date.now()}`;


### PR DESCRIPTION
## Summary
- read data API base URL from VITE_API_BASE env var
- document VITE_API_BASE and add example environment file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c3a64085ec83278f49aa04360dbf06