### PR TITLE
chore: integrate tailwind via build

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,24 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="color-scheme" content="light">
   <title>SEPEP Sports Tracker</title>
-  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
-  <style type="text/tailwindcss">
-    @theme {
-      --color-brand-50: var(--color-emerald-50);
-      --color-brand-100: var(--color-emerald-100);
-      --color-brand-200: var(--color-emerald-200);
-      --color-brand-300: var(--color-emerald-300);
-      --color-brand-400: var(--color-emerald-400);
-      --color-brand-500: var(--color-emerald-500);
-      --color-brand-600: var(--color-emerald-600);
-      --color-brand-700: var(--color-emerald-700);
-      --color-brand-800: var(--color-emerald-800);
-      --color-brand-900: var(--color-emerald-900);
-      --color-brand-950: var(--color-emerald-950);
-
-      --color-accent-500: var(--color-teal-500);
-    }
-  </style>
 </head>
 <body class="bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-200">
   <div id="root"></div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+import colors from 'tailwindcss/colors';
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
@@ -8,7 +10,9 @@ export default {
           light: "#f3f5f7",
           DEFAULT: "#ef4056",
           dark: "#d6243e"
-        }
+        },
+        brand: colors.emerald,
+        accent: colors.teal
       },
       fontFamily: {
         sans: ["Inter", "sans-serif"]


### PR DESCRIPTION
## Summary
- load Tailwind via build pipeline by adding `src/index.css` and importing it
- remove Tailwind CDN script and inline theme block from HTML
- extend Tailwind config with brand and accent color aliases

## Testing
- `npm run build` *(fails: vite: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c3d78932f083279622930f3146173d