### PR TITLE
feat: add tailwind typography and forms plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@vitejs/plugin-react": "^4.2.0",
     "tailwindcss": "^3.4.4",
     "postcss": "^8.4.38",
-    "autoprefixer": "^10.4.16"
+    "autoprefixer": "^10.4.16",
+    "@tailwindcss/typography": "^0.5.10",
+    "@tailwindcss/forms": "^0.5.7"
   }
 }

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -79,7 +79,7 @@ export default function Admin() {
         </button>
         <div className="space-y-2">
           <label className="block font-medium text-slate-900 dark:text-slate-200">Upload Fixtures JSON</label>
-          <input className="block w-full rounded-xl border-slate-300/60 bg-white/80 dark:bg-slate-900/60 px-3 py-2 focus:ring-2 focus:ring-slate-900/20 outline-none" type="file" accept="application/json" onChange={importFixtures} />
+          <input className="form-input w-full rounded-xl" type="file" accept="application/json" onChange={importFixtures} />
         </div>
       </div>
     </section>

--- a/src/pages/MVP.jsx
+++ b/src/pages/MVP.jsx
@@ -4,7 +4,9 @@ export default function MVP() {
     <section id="mvp" className="py-8 sm:py-10 lg:py-14">
       <h2 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">MVP & Fair-Play</h2>
       <div className="mt-6 rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-slate-900/60 dark:ring-white/10 p-5 sm:p-6">
-        <p className="text-sm leading-7 text-slate-600 dark:text-slate-300">Vote tracking coming soon.</p>
+        <div className="prose dark:prose-invert">
+          <p>Vote tracking coming soon.</p>
+        </div>
       </div>
     </section>
   );

--- a/src/pages/News.jsx
+++ b/src/pages/News.jsx
@@ -4,7 +4,9 @@ export default function News() {
     <section id="news" className="py-8 sm:py-10 lg:py-14">
       <h2 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">Announcements & Media</h2>
       <div className="mt-6 rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-slate-900/60 dark:ring-white/10 p-5 sm:p-6">
-        <p className="text-sm leading-7 text-slate-600 dark:text-slate-300">No announcements yet.</p>
+        <div className="prose dark:prose-invert">
+          <p>No announcements yet.</p>
+        </div>
       </div>
     </section>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,6 @@
 import colors from 'tailwindcss/colors';
+import typography from '@tailwindcss/typography';
+import forms from '@tailwindcss/forms';
 
 /** @type {import('tailwindcss').Config} */
 export default {
@@ -19,5 +21,5 @@ export default {
       }
     }
   },
-  plugins: []
+  plugins: [typography, forms]
 };


### PR DESCRIPTION
## Summary
- add typography and forms plugins to Tailwind config
- apply Tailwind prose styling to news and MVP content
- use Tailwind form styles for admin file input

## Testing
- `npm test`
- `npm install -D @tailwindcss/typography @tailwindcss/forms` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68c3dab5668c83278d8151b502d82ba3