### PR TITLE
feat: add announcements editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.3"
+    "react-router-dom": "^6.22.3",
+    "@tiptap/react": "^2.0.0",
+    "@tiptap/starter-kit": "^2.0.0"
   },
   "devDependencies": {
     "vite": "^5.1.0",

--- a/src/lib/dataApi.js
+++ b/src/lib/dataApi.js
@@ -126,10 +126,24 @@ export function saveFixtures(rounds) {
   return rounds;
 }
 
+export function getAnnouncements() {
+  if (cache.announcement) return cache.announcement;
+  const stored = localStorage.getItem('announcement') || '';
+  cache.announcement = stored;
+  return stored;
+}
+
+export function saveAnnouncement(html) {
+  localStorage.setItem('announcement', html);
+  cache.announcement = html;
+  return html;
+}
+
 export async function refreshAll() {
   clearCache();
   localStorage.removeItem('fixtures');
   localStorage.removeItem('results');
   localStorage.removeItem('players');
+  localStorage.removeItem('announcement');
   await Promise.all([getTeams(), getFixtures(), getResults(), getPlayers()]);
 }

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -1,8 +1,14 @@
 import React from 'react';
-import { getResults, saveFixtures, refreshAll } from '../lib/dataApi.js';
+import { getResults, saveFixtures, refreshAll, getAnnouncements, saveAnnouncement } from '../lib/dataApi.js';
+import { useEditor, EditorContent } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
 
 export default function Admin() {
   const [message, setMessage] = React.useState('');
+  const editor = useEditor({
+    extensions: [StarterKit],
+    content: getAnnouncements(),
+  });
 
   async function exportData() {
     const data = await getResults();
@@ -34,6 +40,14 @@ export default function Admin() {
     await refreshAll();
     setMessage('Data refreshed');
     setTimeout(() => setMessage(''), 3000);
+  }
+
+  function handleSaveAnnouncement() {
+    if (editor) {
+      saveAnnouncement(editor.getHTML());
+      setMessage('Announcement saved');
+      setTimeout(() => setMessage(''), 3000);
+    }
   }
   return (
     <section id="admin" className="py-8 sm:py-10 lg:py-14">
@@ -80,6 +94,18 @@ export default function Admin() {
         <div className="space-y-2">
           <label className="block font-medium text-slate-900 dark:text-slate-200">Upload Fixtures JSON</label>
           <input className="form-input w-full rounded-xl" type="file" accept="application/json" onChange={importFixtures} />
+        </div>
+        <div className="space-y-2">
+          <label className="block font-medium text-slate-900 dark:text-slate-200">Announcement</label>
+          <div className="border rounded-xl p-2">
+            <EditorContent editor={editor} />
+          </div>
+          <button
+            className="inline-flex items-center gap-2 rounded-xl bg-brand-600 text-white px-4 py-2 hover:bg-brand-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-700"
+            onClick={handleSaveAnnouncement}
+          >
+            Save Announcement
+          </button>
         </div>
       </div>
     </section>

--- a/src/pages/News.jsx
+++ b/src/pages/News.jsx
@@ -1,12 +1,21 @@
 import React from 'react';
+import { getAnnouncements } from '../lib/dataApi.js';
+
 export default function News() {
+  const [announcement, setAnnouncement] = React.useState('');
+
+  React.useEffect(() => {
+    setAnnouncement(getAnnouncements());
+  }, []);
+
   return (
     <section id="news" className="py-8 sm:py-10 lg:py-14">
       <h2 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">Announcements & Media</h2>
       <div className="mt-6 rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-slate-900/60 dark:ring-white/10 p-5 sm:p-6">
-        <div className="prose dark:prose-invert">
-          <p>No announcements yet.</p>
-        </div>
+        <div
+          className="prose dark:prose-invert"
+          dangerouslySetInnerHTML={{ __html: announcement || '<p>No announcements yet.</p>' }}
+        />
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add Tiptap dependencies for rich text editing
- allow admins to compose announcements and save to storage
- show saved announcements on News page

## Testing
- `npm test`
- `npm install @tiptap/react @tiptap/starter-kit` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tailwindcss%2fforms)*

------
https://chatgpt.com/codex/tasks/task_b_68c3ee27e00c832795336d1e05b15280