### PR TITLE
feat: add SepepHub page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Stats from './pages/Stats.jsx';
 import MVP from './pages/MVP.jsx';
 import News from './pages/News.jsx';
 import Admin from './pages/Admin.jsx';
+import SepepHub from './pages/SepepHub.jsx';
 
 export default function App() {
   const [teacherMode, setTeacherMode] = useState(() => localStorage.getItem('teacherMode') === '1');
@@ -48,6 +49,7 @@ export default function App() {
                 <Route path="/mvp" element={<MVP teacherMode={teacherMode} />} />
                 <Route path="/news" element={<News teacherMode={teacherMode} />} />
                 <Route path="/admin" element={<Admin teacherMode={teacherMode} />} />
+                <Route path="/sepep" element={<SepepHub teacherMode={teacherMode} />} />
               </Routes>
             </div>
           </main>

--- a/src/components/Nav/AppTopbar.jsx
+++ b/src/components/Nav/AppTopbar.jsx
@@ -9,7 +9,8 @@ const links = [
   { to: '/stats', label: 'Stats' },
   { to: '/mvp', label: 'MVP & Fair-Play' },
   { to: '/news', label: 'Announcements & Media' },
-  { to: '/admin', label: 'Admin' }
+  { to: '/admin', label: 'Admin' },
+  { to: '/sepep', label: 'SEPEP Hub' }
 ];
 
 export default function AppTopbar({ teacherMode, toggleTeacher, darkMode, toggleDark }) {

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,6 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+.info-box {
+  @apply mt-4 p-4 bg-emerald-50 border border-emerald-200 rounded;
+}

--- a/src/pages/SepepHub.jsx
+++ b/src/pages/SepepHub.jsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+
+export default function SepepHub() {
+  const [showInfo, setShowInfo] = useState(false);
+
+  return (
+    <div className="max-w-screen-md mx-auto">
+      <h1 className="text-3xl font-bold mb-4">SEPEP Hub</h1>
+      <p className="mb-4">
+        Welcome to the SEPEP Hub. Explore information about the tournament and
+        track all the latest updates.
+      </p>
+      <button
+        onClick={() => setShowInfo(!showInfo)}
+        className="px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white rounded"
+      >
+        {showInfo ? 'Hide' : 'Show'} Info
+      </button>
+      {showInfo && (
+        <div className="info-box">
+          <p>
+            This hub page demonstrates how markup and scripts from a standalone
+            HTML page can be moved into a React component using hooks for state
+            management.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create interactive SepepHub page with toggleable info panel
- extract info box styles to `index.css`
- wire SepepHub into router and top navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c3f9f832ec83279aa7e0fb8020c454