### PR TITLE
Sanitize announcements and remove innerHTML usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "node src/lib/ladder.test.js"
+    "test": "node src/lib/ladder.test.js && node src/lib/sanitizeHtml.test.js"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/src/lib/dataApi.js
+++ b/src/lib/dataApi.js
@@ -1,3 +1,5 @@
+import { sanitizeHtml } from './sanitizeHtml.js';
+
 const BASE = import.meta.env.VITE_API_BASE || "https://script.google.com/macros/s/APP_SCRIPT_ID/exec";
 
 function noCache() {
@@ -134,9 +136,10 @@ export function getAnnouncements() {
 }
 
 export function saveAnnouncement(html) {
-  localStorage.setItem('announcement', html);
-  cache.announcement = html;
-  return html;
+  const sanitized = sanitizeHtml(html);
+  localStorage.setItem('announcement', sanitized);
+  cache.announcement = sanitized;
+  return sanitized;
 }
 
 export async function refreshAll() {

--- a/src/lib/sanitizeHtml.js
+++ b/src/lib/sanitizeHtml.js
@@ -1,0 +1,7 @@
+export function sanitizeHtml(html) {
+  return (html || '')
+    .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '')
+    .replace(/on\w+="[^"]*"/gi, '')
+    .replace(/on\w+='[^']*'/gi, '')
+    .replace(/javascript:/gi, '');
+}

--- a/src/lib/sanitizeHtml.test.js
+++ b/src/lib/sanitizeHtml.test.js
@@ -1,0 +1,18 @@
+import assert from 'assert';
+import { sanitizeHtml } from './sanitizeHtml.js';
+
+(() => {
+  const input = "<img src=x onerror=\"alert('x')\"><p>Hello</p>";
+  const output = sanitizeHtml(input);
+  assert(!/onerror/.test(output));
+  assert(output.includes('<p>Hello</p>'));
+})();
+
+(() => {
+  const input = "<script>alert('x')</script><div>Safe</div>";
+  const output = sanitizeHtml(input);
+  assert(!/<script>/i.test(output));
+  assert(output.includes('<div>Safe</div>'));
+})();
+
+console.log('sanitizeHtml tests passed');

--- a/src/pages/News.jsx
+++ b/src/pages/News.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { getAnnouncements } from '../lib/dataApi.js';
+import { sanitizeHtml } from '../lib/sanitizeHtml.js';
 
 export default function News() {
   const [announcement, setAnnouncement] = React.useState('');
@@ -8,15 +9,33 @@ export default function News() {
     setAnnouncement(getAnnouncements());
   }, []);
 
+  const content = React.useMemo(() => {
+    const html = sanitizeHtml(announcement || '<p>No announcements yet.</p>');
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    return Array.from(doc.body.childNodes).map((node, index) => nodeToElement(node, index));
+  }, [announcement]);
+
   return (
     <section id="news" className="py-8 sm:py-10 lg:py-14">
       <h2 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">Announcements & Media</h2>
       <div className="mt-6 rounded-2xl ring-1 ring-black/5 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:bg-slate-900/60 dark:ring-white/10 p-5 sm:p-6">
-        <div
-          className="prose dark:prose-invert"
-          dangerouslySetInnerHTML={{ __html: announcement || '<p>No announcements yet.</p>' }}
-        />
+        <div className="prose dark:prose-invert">{content}</div>
       </div>
     </section>
   );
+}
+
+function nodeToElement(node, key) {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.textContent;
+  }
+  const children = Array.from(node.childNodes).map((child, idx) => nodeToElement(child, idx));
+  const props = { key };
+  if (node.attributes) {
+    Array.from(node.attributes).forEach(attr => {
+      props[attr.name] = attr.value;
+    });
+  }
+  return React.createElement(node.nodeName.toLowerCase(), props, children);
 }


### PR DESCRIPTION
## Summary
- sanitize announcement HTML before storing and rendering
- render announcements via DOM parsing instead of `dangerouslySetInnerHTML`
- add unit tests covering HTML sanitization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c3fb3a266c8327a96152215d8ce02e