### PR TITLE
Refactor SEPEP Hub to use data parsing hook

### DIFF
--- a/src/lib/sepepData.js
+++ b/src/lib/sepepData.js
@@ -1,0 +1,36 @@
+export function parseScoreboard(data) {
+  try {
+    const list = Array.isArray(data) ? data : JSON.parse(data);
+    return list
+      .filter(item => item && item.status === 'Final')
+      .map(item => ({
+        matchId: item.matchId,
+        homeTeam: item.homeTeam,
+        awayTeam: item.awayTeam,
+        homePoints: Number(item.homePoints) || 0,
+        awayPoints: Number(item.awayPoints) || 0,
+      }));
+  } catch (err) {
+    console.error('Failed to parse scoreboard', err);
+    return [];
+  }
+}
+
+export function parseFixtures(data) {
+  try {
+    const list = Array.isArray(data) ? data : JSON.parse(data);
+    return list.map(item => ({
+      id: item.id,
+      division: item.division,
+      round: item.round,
+      homeTeam: item.homeTeam,
+      awayTeam: item.awayTeam,
+      slot: item.slot ?? null,
+      venue: item.venue ?? null,
+      start: item.start ?? null,
+    }));
+  } catch (err) {
+    console.error('Failed to parse fixtures', err);
+    return [];
+  }
+}

--- a/src/lib/useSepepData.js
+++ b/src/lib/useSepepData.js
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { parseScoreboard, parseFixtures } from './sepepData.js';
+
+export function useSepepData() {
+  const [fixtures, setFixtures] = useState([]);
+  const [scoreboard, setScoreboard] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [fixturesRaw, resultsRaw] = await Promise.all([
+          fetch('/data/fixtures.json').then(res => res.json()),
+          fetch('/data/results.json').then(res => res.json()),
+        ]);
+        setFixtures(parseFixtures(fixturesRaw));
+        setScoreboard(parseScoreboard(resultsRaw));
+      } catch (err) {
+        console.error('Failed to load SEPEP data', err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  return { fixtures, scoreboard, loading };
+}

--- a/src/pages/SepepHub.jsx
+++ b/src/pages/SepepHub.jsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
+import { useSepepData } from '../lib/useSepepData.js';
 
 export default function SepepHub() {
   const [showInfo, setShowInfo] = useState(false);
+  const { fixtures, scoreboard, loading } = useSepepData();
 
   return (
     <div className="max-w-screen-md mx-auto">
@@ -24,6 +26,50 @@ export default function SepepHub() {
             management.
           </p>
         </div>
+      )}
+
+      {loading ? (
+        <p className="mt-6">Loading data...</p>
+      ) : (
+        <>
+          <section className="mt-6">
+            <h2 className="text-xl font-semibold mb-2">Scoreboard</h2>
+            {scoreboard.length ? (
+              <ul>
+                {scoreboard.map(game => (
+                  <li
+                    key={game.matchId}
+                    className="flex justify-between border-b py-1"
+                  >
+                    <span>
+                      {game.homeTeam} vs {game.awayTeam}
+                    </span>
+                    <span>
+                      {game.homePoints} - {game.awayPoints}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p>No results yet.</p>
+            )}
+          </section>
+
+          <section className="mt-6">
+            <h2 className="text-xl font-semibold mb-2">Fixtures</h2>
+            {fixtures.length ? (
+              <ul>
+                {fixtures.slice(0, 5).map(fx => (
+                  <li key={fx.id} className="border-b py-1">
+                    {fx.round}: {fx.homeTeam} vs {fx.awayTeam}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p>No fixtures available.</p>
+            )}
+          </section>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add parsing utilities for scoreboard and fixture data
- create `useSepepData` hook for loading and parsing tournament data
- refactor `SepepHub` to use the new hook and display basic results and fixtures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c3fff3c29c8327a02b5a9742e7b187