### PR TITLE
Add noscript fallback to index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   </head>
   <body class="bg-gradient-to-br from-amber-50 via-blue-50 to-green-50">
     <div id="root"></div>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure index page hints when JavaScript is disabled

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c48642bb888327a3b54db862d9661b