### PR TITLE
chore: remove SEPEP Sports Hub placeholder

### DIFF
--- a/src/SEPEPSportsHub.tsx
+++ b/src/SEPEPSportsHub.tsx
@@ -1,10 +1,6 @@
 import React from 'react'
 
 export default function SEPEPSportsHub() {
-  return (
-    <div className="p-4">
-      {/* TODO: Replace with full SEPEPSportsHub implementation provided separately */}
-      <h1 className="text-2xl font-bold">SEPEP Sports Hub Placeholder</h1>
-    </div>
-  )
+  return <div className="p-4" />
 }
+


### PR DESCRIPTION
## Summary
- remove SEPEP Sports Hub placeholder from stub component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c4975900c08327af1f0c9f80ef208e