### PR TITLE
feat: add student and teacher pages with runtime config + read-only API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
-VITE_API_BASE=https://script.google.com/macros/s/APP_SCRIPT_ID/exec
+VITE_SEPEP_API_URL=        # optional; runtime config file will override
+VITE_POLL_MS=15000

--- a/public/sepep.config.json
+++ b/public/sepep.config.json
@@ -1,0 +1,4 @@
+{
+  "apiUrl": "https://script.google.com/macros/s/YOUR_EXEC_ID/exec",
+  "staffFormUrl": "https://docs.google.com/forms/d/e/YOUR_FORM_ID/viewform?embedded=true"
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,14 @@
+const getBase = () => {
+  const env = (import.meta as any).env?.VITE_SEPEP_API_URL || '';
+  const saved = localStorage.getItem('sepep_api_url') || '';
+  const base = (saved || env || '').replace(/\/exec.*$/, '');
+  return base ? base + '/exec' : '';
+};
+
+export async function fetchSummary() {
+  const base = getBase();
+  if (!base) throw new Error('Missing SEPEP API URL');
+  const r = await fetch(`${base}?action=summary`, { cache: 'no-store' });
+  if (!r.ok) throw new Error(`API ${r.status}`);
+  return r.json();
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,9 @@
+export type SepepConfig = { apiUrl?: string; staffFormUrl?: string };
+export async function loadConfig(): Promise<SepepConfig> {
+  try {
+    const url = ((import.meta as any).env?.BASE_URL || '/') + 'sepep.config.json';
+    const r = await fetch(url, { cache: 'no-store' });
+    if (r.ok) return r.json();
+  } catch {}
+  return {};
+}

--- a/src/pages/Student.tsx
+++ b/src/pages/Student.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom/client';
+import '../index.css';
+import { loadConfig } from '../lib/config';
+import { fetchSummary } from '../lib/api';
+
+type Houses = Record<string, number>;
+type Row = { YearLevel?: string; HomeTeam?: string; AwayTeam?: string; HomeScore?: number|string; AwayScore?: number|string; Round?: string; Status?: string };
+
+function StudentApp() {
+  const [houses, setHouses] = useState<Houses>({});
+  const [rows, setRows] = useState<Row[]>([]);
+  const [lastUpdated, setLastUpdated] = useState<string>('');
+  const [error, setError] = useState<string>('');
+
+  const toResults = (rws: Row[] = []) => rws
+    .filter(r => r.HomeTeam && r.AwayTeam)
+    .map(r => ({ homeTeam: r.HomeTeam, awayTeam: r.AwayTeam, score: `${r.HomeScore}-${r.AwayScore}`, round: r.Round || 'Latest', status: r.Status || 'Final' }));
+
+  useEffect(() => {
+    (async () => {
+      const cfg = await loadConfig();
+      if (cfg.apiUrl) localStorage.setItem('sepep_api_url', cfg.apiUrl);
+      const tick = async () => {
+        try {
+          const data = await fetchSummary();
+          setHouses(data.houses || {});
+          setRows(data.rows || []);
+          setLastUpdated(new Date().toLocaleString());
+          setError('');
+        } catch (e:any) {
+          setError('Missing or invalid API URL (see sepep.config.json)');
+        }
+      };
+      await tick();
+      const id = setInterval(tick, Number((import.meta as any).env?.VITE_POLL_MS ?? 15000));
+      return () => clearInterval(id);
+    })();
+  }, []);
+
+  const sortedHouses = Object.entries(houses).sort(([,a],[,b]) => Number(b)-Number(a));
+  const latest = toResults(rows).slice(0, 10);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-blue-50 to-green-50">
+      <header className="bg-white/80 backdrop-blur-lg border-b border-white/20 sticky top-0 z-40">
+        <div className="max-w-6xl mx-auto px-4 h-16 flex items-center justify-between">
+          <h1 className="text-2xl font-bold text-slate-800">SEPEP Student Hub</h1>
+          <div className="text-xs text-slate-500">Last update: {lastUpdated || '—'}</div>
+        </div>
+      </header>
+
+      <main className="max-w-6xl mx-auto px-4 py-8 space-y-8">
+        {error && <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-red-700">{error}</div>}
+
+        <section className="rounded-2xl border border-white/20 bg-white/80 p-6 shadow-xl">
+          <h2 className="text-xl font-semibold text-slate-800 mb-4">House Championship</h2>
+          <div className="space-y-3">
+            {sortedHouses.map(([house,score])=>(
+              <div key={house} className="flex items-center justify-between">
+                <span className="font-medium text-slate-800">{house}</span>
+                <span className="text-slate-700">{score}</span>
+              </div>
+            ))}
+            {!sortedHouses.length && <p className="text-slate-600">No data yet.</p>}
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-white/20 bg-white/80 p-6 shadow-xl">
+          <h2 className="text-xl font-semibold text-slate-800 mb-4">Latest Matches</h2>
+          <div className="space-y-3">
+            {latest.map((m,i)=>(
+              <div key={i} className="flex items-center justify-between bg-slate-50 rounded-lg p-3">
+                <span className="text-slate-800 font-medium">{m.homeTeam} vs {m.awayTeam}</span>
+                <span className="font-bold text-slate-900">{m.score}</span>
+              </div>
+            ))}
+            {!latest.length && <p className="text-slate-600">No recent results yet.</p>}
+          </div>
+        </section>
+      </main>
+
+      <footer className="text-center text-xs text-slate-500 py-6">© SEPEP</footer>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<StudentApp />);

--- a/src/pages/Teacher.tsx
+++ b/src/pages/Teacher.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom/client';
+import '../index.css';
+import { loadConfig } from '../lib/config';
+
+function TeacherApp(){
+  const [formUrl, setFormUrl] = useState<string>('');
+  const [apiUrl, setApiUrl] = useState<string>('');
+
+  useEffect(() => {
+    (async () => {
+      const cfg = await loadConfig();
+      if (cfg.apiUrl) { localStorage.setItem('sepep_api_url', cfg.apiUrl); setApiUrl(cfg.apiUrl); }
+      if (cfg.staffFormUrl) setFormUrl(cfg.staffFormUrl);
+    })();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100">
+      <header className="bg-white/80 backdrop-blur-lg border-b border-white/20 sticky top-0 z-40">
+        <div className="max-w-6xl mx-auto px-4 h-16 flex items-center justify-between">
+          <h1 className="text-2xl font-bold text-slate-800">SEPEP Teacher</h1>
+          <div className="text-xs text-slate-500 truncate max-w-[60%]">API: {apiUrl || 'not set (see sepep.config.json)'}</div>
+        </div>
+      </header>
+
+      <main className="max-w-6xl mx-auto px-4 py-6 space-y-4">
+        {!formUrl ? (
+          <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-amber-800">
+            Add your Google Form embed URL to <code>public/sepep.config.json</code>.
+          </div>
+        ) : (
+          <div className="rounded-2xl border border-white/20 bg-white/80 p-2 shadow-xl">
+            <iframe title="SEPEP Staff Form" src={formUrl} className="w-full h-[80vh] rounded-lg" allow="clipboard-write; clipboard-read"></iframe>
+          </div>
+        )}
+        <p className="text-slate-600 text-sm">This page writes via Google Form; the Student page reads from the sheet every ~15s.</p>
+      </main>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<TeacherApp />);

--- a/student/index.html
+++ b/student/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SEPEP Student Hub</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/pages/Student.tsx"></script>
+  </body>
+</html>

--- a/teacher/index.html
+++ b/teacher/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SEPEP Teacher</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/pages/Teacher.tsx"></script>
+  </body>
+</html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,18 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [react()],
+  // Set your repo name here so assets resolve on GitHub Pages:
   base: '/Murray-Bridge-High-School-2025-SEPEP/',
-})
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        student: resolve(__dirname, 'student/index.html'),
+        teacher: resolve(__dirname, 'teacher/index.html'),
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add runtime `sepep.config.json` loader and read-only API client
- introduce `/student` hub and `/teacher` form pages
- configure Vite for multi-page GitHub Pages builds

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c504339bc48327aaa5fe733b32479c