### PR TITLE
feat(ui): apply sports color system (blue+amber), tokens & consistent components

### DIFF
--- a/src/components/ui/BadgeLive.tsx
+++ b/src/components/ui/BadgeLive.tsx
@@ -1,6 +1,6 @@
 export default function BadgeLive({label='LIVE'}:{label?:string}) {
   return (
-    <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold bg-red-600 text-white">
+    <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold bg-danger text-white">
       <span className="mr-1 inline-block h-2 w-2 rounded-full bg-white animate-pulse"></span>
       {label}
     </span>

--- a/src/components/ui/Ladder.tsx
+++ b/src/components/ui/Ladder.tsx
@@ -10,7 +10,7 @@ export default function Ladder({houses}:{houses:Record<string,number>}) {
   return (
     <div className="space-y-3">
       {sorted.map(([name,score],i)=>(
-        <div key={name} className="flex items-center justify-between bg-slate-50 dark:bg-slate-800/60 rounded-xl p-3">
+        <div key={name} className="flex items-center justify-between bg-white odd:bg-slate-50 dark:bg-slate-800/60 dark:odd:bg-slate-800/40 rounded-xl p-3">
           <div className="flex items-center gap-3">
             <span className="text-sm font-semibold text-slate-500 w-6 text-right">{i+1}</span>
             <span className={`px-2 py-1 rounded ${color(name)} font-medium`}>{name}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -5,15 +5,13 @@
 :root { color-scheme: light dark; }
 html, body { @apply antialiased; }
 html, body, #root { height: 100%; }
-.btn { @apply inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2 font-medium transition;
-       @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 }
-.btn-primary { @apply bg-slate-900 text-white hover:bg-slate-800 focus-visible:ring-slate-900 }
-.btn-accent  { @apply bg-accent-500 text-white hover:bg-accent-600 focus-visible:ring-accent-600 }
-.btn-ghost   { @apply ring-1 ring-slate-300 bg-white text-slate-800 hover:bg-slate-50 }
-.card { @apply rounded-2xl border border-white/20 bg-white/80 dark:bg-slate-900/60 shadow-card hover:scale-[1.01] transition }
+.btn { @apply inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2 font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2; }
+.btn-primary { @apply bg-slate-900 text-white hover:bg-slate-800 focus-visible:ring-slate-900; }
+.btn-accent  { @apply bg-accent-500 text-slate-900 hover:bg-accent-600 focus-visible:ring-accent-600; }
+.btn-ghost   { @apply ring-1 ring-slate-300 bg-white text-slate-800 hover:bg-slate-50; }
+.card  { @apply rounded-2xl border border-white/20 bg-white/80 dark:bg-slate-900/60 shadow-card; }
 .h1 { @apply text-3xl sm:text-4xl font-extrabold text-slate-900 dark:text-white leading-tight }
 .h2 { @apply text-2xl font-bold text-slate-800 dark:text-slate-100 }
-.sub { @apply text-slate-600 }
 .muted { @apply text-xs text-slate-500 }
 /* 8-pt rhythm helpers (optional) */
 .pad { @apply p-6 sm:p-8 } .gap { @apply gap-6 } .gap-lg { @apply gap-8 }

--- a/src/pages/Student.tsx
+++ b/src/pages/Student.tsx
@@ -44,7 +44,7 @@ function StudentApp() {
   const latest = toResults(rows).slice(0, 10);
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-blue-50 to-green-50">
       <div role="status" aria-live="polite" className="sr-only" id="a11y-updates" />
       <header className="bg-white/80 backdrop-blur-lg border-b border-white/20 sticky top-0 z-40">
         <div className="max-w-6xl mx-auto pad flex items-center justify-between">
@@ -63,7 +63,7 @@ function StudentApp() {
         <Card title="Latest Matches">
           <div className="space-y-3">
             {latest.map((m,i)=>(
-              <div key={i} className="flex items-center justify-between bg-slate-50 dark:bg-slate-800/60 rounded-lg p-3">
+              <div key={i} className="flex items-center justify-between bg-white odd:bg-slate-50 dark:bg-slate-800/60 dark:odd:bg-slate-800/40 rounded-lg p-3">
                 <span className="text-slate-800 font-medium">{m.homeTeam} vs {m.awayTeam}</span>
                 <span className="font-bold text-slate-900 text-right">{m.score}</span>
               </div>

--- a/src/pages/Teacher.tsx
+++ b/src/pages/Teacher.tsx
@@ -18,7 +18,7 @@ function TeacherApp(){
   }, []);
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-blue-50 to-green-50">
       <div role="status" aria-live="polite" className="sr-only" id="a11y-updates" />
       <header className="bg-white/80 backdrop-blur-lg border-b border-white/20 sticky top-0 z-40">
         <div className="max-w-6xl mx-auto pad flex items-center justify-between">
@@ -34,7 +34,7 @@ function TeacherApp(){
             <p className="muted mt-3">Submissions appear in the Student Hub within ~15s.</p>
           </Card>
         ) : (
-          <div className="card pad text-amber-800 bg-amber-50 border-amber-200">
+          <div className="card pad text-warning bg-warning/10 border-warning/20">
             Add your Google Form embed URL to <code>public/sepep.config.json</code>.
           </div>
         )}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,11 +1,12 @@
 import type { Config } from 'tailwindcss';
 
 export default {
-  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  content: ["./index.html", "./**/*.html", "./src/**/*.{ts,tsx,js}"],
   theme: {
     extend: {
       colors: {
         brand: { 50:"#eef2ff",100:"#e0e7ff",400:"#6366f1",600:"#4f46e5",800:"#3730a3" },
+        brandBase: "#2563eb",
         accent:{ 50:"#fff7ed",100:"#ffedd5",500:"#f59e0b",600:"#d97706" },
         success:"#16a34a", warning:"#f59e0b", danger:"#dc2626",
         house: { blue:"#2563eb", red:"#dc2626", green:"#16a34a", yellow:"#ca8a04" }


### PR DESCRIPTION
## Summary
- add Tailwind tokens for blue/amber brand palette and status colors
- centralize button/card utilities with accessible contrast
- refresh student and teacher pages with gradient backgrounds, zebra rows and tokenized chips

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c5364841f4832780c6f946f1042833