### PR TITLE
feat(ui): apply MBHS colour theme + neighbourhood data colours

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>Murray Bridge HS • SEPEP 2025</title>
     <meta name="theme-color" content="#0f172a" />
   </head>
-  <body class="bg-gradient-to-br from-amber-50 via-blue-50 to-green-50">
+  <body class="bg-gradient-to-br from-mbhs-white via-slate-50 to-mbhs-white">
     <div id="root"></div>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script type="module" src="/src/main.tsx"></script>

--- a/src/SEPEPSportsHub.tsx
+++ b/src/SEPEPSportsHub.tsx
@@ -201,7 +201,7 @@ const ScoreUpdateModal: React.FC<{
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
       <div className="w-full max-w-md rounded-2xl bg-white p-8 shadow-2xl">
         <div className="mb-6 flex items-center justify-between">
-          <h3 className="text-xl font-bold text-slate-800">Update Score</h3>
+          <h3 className="text-xl font-bold text-mbhs-navy">Update Score</h3>
           <button onClick={onClose} className="rounded-lg p-2 transition-colors hover:bg-slate-100">
             <X className="h-5 w-5 text-slate-600" />
           </button>
@@ -213,7 +213,7 @@ const ScoreUpdateModal: React.FC<{
             <select
               value={selectedYear}
               onChange={(e) => setSelectedYear(e.target.value)}
-              className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-amber-500 focus:ring-2 focus:ring-amber-500"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-mbhs-gold focus:ring-2 focus:ring-mbhs-gold"
             >
               <option value="">Select year level</option>
               {yearLevels.map((year) => (
@@ -230,7 +230,7 @@ const ScoreUpdateModal: React.FC<{
               <select
                 value={selectedTeam1}
                 onChange={(e) => setSelectedTeam1(e.target.value)}
-                className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-amber-500 focus:ring-2 focus:ring-amber-500"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-mbhs-gold focus:ring-2 focus:ring-mbhs-gold"
               >
                 <option value="">Select team</option>
                 {teams.map((team) => (
@@ -246,7 +246,7 @@ const ScoreUpdateModal: React.FC<{
               <select
                 value={selectedTeam2}
                 onChange={(e) => setSelectedTeam2(e.target.value)}
-                className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-amber-500 focus:ring-2 focus:ring-amber-500"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-mbhs-gold focus:ring-2 focus:ring-mbhs-gold"
               >
                 <option value="">Select team</option>
                 {teams
@@ -267,7 +267,7 @@ const ScoreUpdateModal: React.FC<{
                 type="number"
                 value={score1}
                 onChange={(e) => setScore1(e.target.value)}
-                className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-amber-500 focus:ring-2 focus:ring-amber-500"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-mbhs-gold focus:ring-2 focus:ring-mbhs-gold"
                 min={0}
                 placeholder="0"
               />
@@ -278,7 +278,7 @@ const ScoreUpdateModal: React.FC<{
                 type="number"
                 value={score2}
                 onChange={(e) => setScore2(e.target.value)}
-                className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-amber-500 focus:ring-2 focus:ring-amber-500"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-mbhs-gold focus:ring-2 focus:ring-mbhs-gold"
                 min={0}
                 placeholder="0"
               />
@@ -293,7 +293,7 @@ const ScoreUpdateModal: React.FC<{
           <button
             onClick={handleSave}
             disabled={saving || !selectedTeam1 || !selectedTeam2 || !score1 || !score2}
-            className="flex-1 inline-flex items-center justify-center space-x-2 rounded-lg bg-amber-600 px-4 py-2 font-medium text-white transition-colors hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex-1 btn btn-accent justify-center space-x-2 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {saving ? (
               <>
@@ -338,10 +338,10 @@ const SEPEPSportsHub: React.FC = () => {
   const sheets = useGoogleSheets();
 
   const houseColors: Record<string, string> = {
-    Wirakuthi: "from-blue-500 to-blue-600",
-    Pondi: "from-red-500 to-red-600",
-    Kungari: "from-green-500 to-green-600",
-    "No:RI": "from-yellow-500 to-yellow-600",
+    Wirakuthi: "from-hood-wirakuthi to-hood-wirakuthi",
+    Pondi: "from-hood-pondi to-hood-pondi",
+    Kungari: "from-hood-kungari to-hood-kungari",
+    "No:RI": "from-hood-nori to-hood-nori",
   };
 
   const showNotification = useCallback((message: string, type: Notification["type"] = "info") => {
@@ -537,16 +537,16 @@ const SEPEPSportsHub: React.FC = () => {
   ] as const;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-blue-50 to-green-50">
+    <div className="min-h-screen bg-gradient-to-br from-mbhs-white via-slate-50 to-mbhs-white">
       {/* Header */}
-      <header className="sticky top-0 z-40 border-b border-white/20 bg-white/80 backdrop-blur-lg">
+      <header className="sticky top-0 z-40 bg-mbhs-navy text-white">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="flex h-16 items-center justify-between">
             <div className="flex items-center space-x-4">
-              <Trophy className="h-8 w-8 text-amber-600" />
+              <Trophy className="h-8 w-8 text-mbhs-gold" />
               <div>
-                <h1 className="text-2xl font-bold text-slate-800">2024 Neighbourhood SEPEP</h1>
-                <p className="text-sm text-slate-600">Live Sports Hub with Google Sheets</p>
+                <h1 className="text-2xl font-bold">2024 Neighbourhood SEPEP</h1>
+                <p className="text-sm text-white/80">Live Sports Hub with Google Sheets</p>
               </div>
             </div>
 
@@ -554,13 +554,13 @@ const SEPEPSportsHub: React.FC = () => {
               <div className="flex items-center space-x-2">
                 {sheets.isConnected ? (
                   <>
-                    <Cloud className="h-4 w-4 text-green-600" />
-                    <span className="text-sm font-medium text-green-600">Connected</span>
+                    <Cloud className="h-4 w-4 text-green-500" />
+                    <span className="text-sm font-medium text-green-400">Connected</span>
                   </>
                 ) : (
                   <>
-                    <CloudOff className="h-4 w-4 text-slate-400" />
-                    <span className="text-sm text-slate-400">Offline</span>
+                    <CloudOff className="h-4 w-4 text-white/70" />
+                    <span className="text-sm text-white/70">Offline</span>
                   </>
                 )}
               </div>
@@ -568,21 +568,21 @@ const SEPEPSportsHub: React.FC = () => {
               {sepepData.loaded && (
                 <button
                   onClick={() => setShowScoreModal(true)}
-                  className="inline-flex items-center space-x-1 rounded-lg bg-amber-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-amber-700"
+                  className="btn btn-accent text-sm"
                 >
                   <Plus className="h-4 w-4" />
                   <span>Update Score</span>
                 </button>
               )}
 
-              {sheets.lastSync && <span className="text-xs text-slate-500">Last sync: {sheets.lastSync.toLocaleTimeString()}</span>}
+              {sheets.lastSync && <span className="text-xs text-white/70">Last sync: {sheets.lastSync.toLocaleTimeString()}</span>}
             </div>
           </div>
         </div>
       </header>
 
       {/* Navigation */}
-      <nav className="border-b border-white/20 bg-white/60 backdrop-blur-lg">
+      <nav className="border-b border-slate-200/60 bg-white">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="flex space-x-1 overflow-x-auto py-4">
             {navItems.map((item) => {
@@ -592,7 +592,7 @@ const SEPEPSportsHub: React.FC = () => {
                   key={item.id}
                   onClick={() => setActiveSection(item.id)}
                   className={`whitespace-nowrap rounded-full px-4 py-2 font-medium transition-all duration-200 ${
-                    activeSection === item.id ? "bg-slate-800 text-white shadow-lg" : "text-slate-600 hover:bg-white/60 hover:text-slate-800"
+                    activeSection === item.id ? "bg-mbhs-navy text-white" : "text-slate-700 hover:bg-slate-100"
                   }`}
                 >
                   <span className="inline-flex items-center space-x-2">
@@ -612,7 +612,7 @@ const SEPEPSportsHub: React.FC = () => {
           <div
             key={n.id}
             className={`max-w-sm transform rounded-lg p-4 shadow-lg backdrop-blur-lg transition-all duration-300 ${
-              n.type === "success" ? "bg-green-500/90 text-white" : n.type === "error" ? "bg-red-500/90 text-white" : "bg-blue-500/90 text-white"
+              n.type === "success" ? "bg-green-500/90 text-white" : n.type === "error" ? "bg-red-500/90 text-white" : "bg-mbhs-blue/90 text-white"
             }`}
           >
             <p className="text-sm font-medium">{n.message}</p>
@@ -626,15 +626,15 @@ const SEPEPSportsHub: React.FC = () => {
         {activeSection === "upload" && (
           <div className="space-y-8">
             <div className="text-center">
-              <h2 className="mb-4 text-3xl font-bold text-slate-800">Setup & Google Sheets Integration</h2>
+              <h2 className="mb-4 text-3xl font-bold text-mbhs-navy">Setup & Google Sheets Integration</h2>
               <p className="text-slate-600">Connect your Google Sheet for real-time data sync</p>
             </div>
 
             <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
               {/* Sheets connect */}
               <div className="rounded-2xl border border-white/20 bg-white/80 p-8 shadow-xl backdrop-blur-lg">
-                <h3 className="mb-6 flex items-center text-xl font-semibold text-slate-800">
-                  <Cloud className="mr-2 h-5 w-5 text-blue-600" />
+                <h3 className="mb-6 flex items-center text-xl font-semibold text-mbhs-navy">
+                  <Cloud className="mr-2 h-5 w-5 text-mbhs-blue" />
                   Google Sheets Integration
                 </h3>
 
@@ -645,7 +645,7 @@ const SEPEPSportsHub: React.FC = () => {
                       <input
                         type="text"
                         placeholder="https://docs.google.com/spreadsheets/d/YOUR_SHEET_ID"
-                        className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
+                        className="w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-mbhs-blue focus:ring-2 focus:ring-mbhs-blue"
                         onChange={() => {
                           /* noop: controlled by connect button below */
                         }}
@@ -656,7 +656,7 @@ const SEPEPSportsHub: React.FC = () => {
                     <button
                       onClick={() => handleSheetsConnection("https://docs.google.com/spreadsheets/d/sample-demo-sheet")}
                       disabled={loading}
-                      className="flex w-full items-center justify-center space-x-2 rounded-lg bg-blue-600 px-4 py-3 font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+                      className="btn btn-primary w-full items-center justify-center space-x-2 disabled:opacity-50"
                     >
                       {loading ? (
                         <>
@@ -701,13 +701,13 @@ const SEPEPSportsHub: React.FC = () => {
 
               {/* Sample Data */}
               <div className="rounded-2xl border border-white/20 bg-white/80 p-8 shadow-xl backdrop-blur-lg">
-                <h3 className="mb-6 text-xl font-semibold text-slate-800">Try Sample Data</h3>
+                <h3 className="mb-6 text-xl font-semibold text-mbhs-navy">Try Sample Data</h3>
                 <p className="mb-6 text-slate-600">Load demo data that matches your SEPEP format to see the app in action.</p>
 
                 <button
                   onClick={loadSampleData}
                   disabled={loading}
-                  className="flex w-full items-center justify-center space-x-2 rounded-lg bg-slate-800 px-4 py-3 font-medium text-white transition-colors hover:bg-slate-900 disabled:opacity-50"
+                  className="btn btn-primary w-full items-center justify-center space-x-2 disabled:opacity-50"
                 >
                   {loading ? (
                     <>
@@ -722,20 +722,20 @@ const SEPEPSportsHub: React.FC = () => {
                   )}
                 </button>
 
-                <div className="mt-6 rounded-2xl border border-blue-200 bg-blue-50 p-6">
-                  <h4 className="mb-2 text-lg font-semibold text-blue-800">📋 How to Connect Your Google Sheet</h4>
+                <div className="mt-6 rounded-2xl border border-mbhs-blue/20 bg-mbhs-blue/10 p-6">
+                  <h4 className="mb-2 text-lg font-semibold text-mbhs-navy">📋 How to Connect Your Google Sheet</h4>
                   <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
                     <div>
-                      <h5 className="mb-2 font-medium text-blue-700">Step 1: Prepare Your Sheet</h5>
-                      <ul className="list-inside list-disc space-y-1 text-sm text-blue-600">
+                      <h5 className="mb-2 font-medium text-mbhs-blue">Step 1: Prepare Your Sheet</h5>
+                      <ul className="list-inside list-disc space-y-1 text-sm text-mbhs-blue">
                         <li>Open your “2024 SEPEP Fixture and Results.xlsx”</li>
                         <li>Upload to Google Drive and convert to Google Sheets</li>
                         <li>Ensure tabs: Scoreboard, Fixture, Year level sheets</li>
                       </ul>
                     </div>
                     <div>
-                      <h5 className="mb-2 font-medium text-blue-700">Step 2: Share Your Sheet</h5>
-                      <ul className="list-inside list-disc space-y-1 text-sm text-blue-600">
+                      <h5 className="mb-2 font-medium text-mbhs-blue">Step 2: Share Your Sheet</h5>
+                      <ul className="list-inside list-disc space-y-1 text-sm text-mbhs-blue">
                         <li>Click “Share” in Google Sheets</li>
                         <li>Change to “Anyone with the link can view”</li>
                         <li>Copy the URL and connect above</li>
@@ -766,18 +766,18 @@ const SEPEPSportsHub: React.FC = () => {
         {activeSection === "overview" && (
           <div className="space-y-8">
             <div className="text-center">
-              <h2 className="mb-2 text-3xl font-bold text-slate-800">Season Overview</h2>
+              <h2 className="mb-2 text-3xl font-bold text-mbhs-navy">Season Overview</h2>
               <p className="text-slate-600">Your 2024 Neighbourhood SEPEP at a glance</p>
             </div>
 
             {!sepepData.loaded ? (
               <div className="rounded-2xl border border-white/20 bg-white/80 p-8 text-center shadow-xl backdrop-blur-lg">
                 <Settings className="mx-auto mb-4 h-16 w-16 text-slate-400" />
-                <h3 className="mb-2 text-xl font-semibold text-slate-800">No Data Loaded</h3>
+                <h3 className="mb-2 text-xl font-semibold text-mbhs-navy">No Data Loaded</h3>
                 <p className="mb-4 text-slate-600">Connect your Google Sheet or load sample data to see the overview.</p>
                 <button
                   onClick={() => setActiveSection("upload")}
-                  className="inline-flex items-center space-x-2 rounded-lg bg-amber-600 px-4 py-2 font-medium text-white transition-colors hover:bg-amber-700"
+                  className="btn btn-accent inline-flex items-center space-x-2"
                 >
                   <Settings className="h-4 w-4" />
                   <span>Go to Setup</span>
@@ -789,11 +789,11 @@ const SEPEPSportsHub: React.FC = () => {
                   <div className="flex items-center justify-between">
                     <div>
                       <p className="text-sm font-medium text-slate-600">Total Matches</p>
-                      <p className="text-3xl font-bold text-slate-800">
+                      <p className="text-3xl font-bold text-mbhs-navy">
                         {Object.values(sepepData.results).reduce((total, year) => total + (year.matches?.length || 0), 0)}
                       </p>
                     </div>
-                    <Target className="h-8 w-8 text-blue-600" />
+                    <Target className="h-8 w-8 text-mbhs-blue" />
                   </div>
                 </div>
 
@@ -801,7 +801,7 @@ const SEPEPSportsHub: React.FC = () => {
                   <div className="flex items-center justify-between">
                     <div>
                       <p className="text-sm font-medium text-slate-600">Active Teams</p>
-                      <p className="text-3xl font-bold text-slate-800">
+                      <p className="text-3xl font-bold text-mbhs-navy">
                         {Object.values(sepepData.results).reduce((total, year) => total + (year.standings?.length || 0), 0)}
                       </p>
                     </div>
@@ -813,7 +813,7 @@ const SEPEPSportsHub: React.FC = () => {
                   <div className="flex items-center justify-between">
                     <div>
                       <p className="text-sm font-medium text-slate-600">Year Levels</p>
-                      <p className="text-3xl font-bold text-slate-800">{sepepData.yearLevels.length}</p>
+                      <p className="text-3xl font-bold text-mbhs-navy">{sepepData.yearLevels.length}</p>
                     </div>
                     <BarChart3 className="h-8 w-8 text-purple-600" />
                   </div>
@@ -823,13 +823,13 @@ const SEPEPSportsHub: React.FC = () => {
                   <div className="flex items-center justify-between">
                     <div>
                       <p className="text-sm font-medium text-slate-600">{sheets.isConnected ? "Live Updates" : "Offline Mode"}</p>
-                      <p className="text-3xl font-bold text-slate-800">{sheets.isConnected ? "🔗" : "💾"}</p>
+                      <p className="text-3xl font-bold text-mbhs-navy">{sheets.isConnected ? "🔗" : "💾"}</p>
                     </div>
                     {sheets.isConnected ? <Cloud className="h-8 w-8 text-green-600" /> : <CloudOff className="h-8 w-8 text-slate-400" />}
                   </div>
                 </div>
 
-                <div className="lg:col-span-4 rounded-2xl bg-gradient-to-r from-amber-500 to-amber-600 p-8 text-white">
+                <div className="lg:col-span-4 rounded-2xl bg-mbhs-gold p-8 text-white">
                   <div className="flex items-center justify-between">
                     <div>
                       <h3 className="mb-2 text-2xl font-bold">Championship Leader</h3>
@@ -852,14 +852,14 @@ const SEPEPSportsHub: React.FC = () => {
         {activeSection === "houses" && (
           <div className="space-y-8">
             <div className="text-center">
-              <h2 className="mb-4 text-3xl font-bold text-slate-800">House Championships</h2>
+              <h2 className="mb-4 text-3xl font-bold text-mbhs-navy">House Championships</h2>
               <p className="text-slate-600">{sheets.isConnected ? "Live standings synced with Google Sheets" : "Standings from local/sample data"}</p>
             </div>
 
             {!sepepData.loaded ? (
               <div className="rounded-2xl border border-white/20 bg-white/80 p-8 text-center shadow-xl">
                 <Trophy className="mx-auto mb-4 h-16 w-16 text-slate-400" />
-                <h3 className="mb-2 text-xl font-semibold text-slate-800">No House Data Available</h3>
+                <h3 className="mb-2 text-xl font-semibold text-mbhs-navy">No House Data Available</h3>
                 <p className="text-slate-600">Connect your Google Sheet or load sample data to see house scores.</p>
               </div>
             ) : (
@@ -900,27 +900,27 @@ const SEPEPSportsHub: React.FC = () => {
         {activeSection === "fixtures" && (
           <div className="space-y-8">
             <div className="text-center">
-              <h2 className="mb-4 text-3xl font-bold text-slate-800">Competition Fixtures</h2>
+              <h2 className="mb-4 text-3xl font-bold text-mbhs-navy">Competition Fixtures</h2>
               <p className="text-slate-600">Weekly sport schedules by year level</p>
             </div>
 
             {!sepepData.loaded ? (
               <div className="rounded-2xl border border-white/20 bg-white/80 p-8 text-center shadow-xl">
                 <Calendar className="mx-auto mb-4 h-16 w-16 text-slate-400" />
-                <h3 className="mb-2 text-xl font-semibold text-slate-800">No Fixture Data Available</h3>
+                <h3 className="mb-2 text-xl font-semibold text-mbhs-navy">No Fixture Data Available</h3>
                 <p className="text-slate-600">Load your SEPEP data to see weekly fixtures.</p>
               </div>
             ) : (
               <div className="space-y-6">
                 {sepepData.fixtures.map((week) => (
                   <div key={String(week.week)} className="rounded-2xl border border-white/20 bg-white/80 p-8 shadow-xl">
-                    <h3 className="mb-6 text-2xl font-bold text-slate-800">Week {String(week.week)}</h3>
+                    <h3 className="mb-6 text-2xl font-bold text-mbhs-navy">Week {String(week.week)}</h3>
                     <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
                       {Object.entries(week)
                         .filter(([k]) => k !== "week")
                         .map(([yearLevel, sport]) => (
-                          <div key={yearLevel} className="rounded-xl border-l-4 border-amber-500 bg-slate-50 p-6">
-                            <h4 className="mb-2 font-semibold text-slate-800">{yearLevel}</h4>
+                          <div key={yearLevel} className="rounded-xl border-l-4 border-mbhs-gold bg-slate-50 p-6">
+                            <h4 className="mb-2 font-semibold text-mbhs-navy">{yearLevel}</h4>
                             <p className="text-slate-600">{String(sport)}</p>
                           </div>
                         ))}
@@ -937,14 +937,14 @@ const SEPEPSportsHub: React.FC = () => {
           <div className="space-y-8">
             <div className="flex items-center justify-between">
               <div className="flex-1 text-center">
-                <h2 className="mb-4 text-3xl font-bold text-slate-800">Live Results</h2>
+                <h2 className="mb-4 text-3xl font-bold text-mbhs-navy">Live Results</h2>
                 <p className="text-slate-600">Team standings and match results</p>
               </div>
 
               {sepepData.loaded && (
                 <button
                   onClick={() => setShowScoreModal(true)}
-                  className="inline-flex items-center space-x-2 rounded-lg bg-amber-600 px-4 py-2 font-medium text-white transition-colors hover:bg-amber-700"
+                  className="btn btn-accent inline-flex items-center space-x-2"
                 >
                   <Edit3 className="h-4 w-4" />
                   <span>Update Score</span>
@@ -959,7 +959,7 @@ const SEPEPSportsHub: React.FC = () => {
                     <button
                       onClick={() => setSelectedYearLevel("all")}
                       className={`rounded-full px-4 py-2 font-medium transition-colors ${
-                        selectedYearLevel === "all" ? "bg-slate-800 text-white" : "text-slate-600 hover:bg-white/60"
+                        selectedYearLevel === "all" ? "bg-mbhs-navy text-white" : "text-slate-700 hover:bg-slate-100"
                       }`}
                     >
                       All Years
@@ -969,7 +969,7 @@ const SEPEPSportsHub: React.FC = () => {
                         key={year}
                         onClick={() => setSelectedYearLevel(year)}
                         className={`rounded-full px-4 py-2 font-medium transition-colors ${
-                          selectedYearLevel === year ? "bg-slate-800 text-white" : "text-slate-600 hover:bg-white/60"
+                          selectedYearLevel === year ? "bg-mbhs-navy text-white" : "text-slate-700 hover:bg-slate-100"
                         }`}
                       >
                         {year.replace("Year ", "Y").replace(" (", " L").replace(")", "")}
@@ -983,7 +983,7 @@ const SEPEPSportsHub: React.FC = () => {
             {!sepepData.loaded ? (
               <div className="rounded-2xl border border-white/20 bg-white/80 p-8 text-center shadow-xl">
                 <BarChart3 className="mx-auto mb-4 h-16 w-16 text-slate-400" />
-                <h3 className="mb-2 text-xl font-semibold text-slate-800">No Results Data Available</h3>
+                <h3 className="mb-2 text-xl font-semibold text-mbhs-navy">No Results Data Available</h3>
                 <p className="text-slate-600">Connect your Google Sheet or load sample data to see results.</p>
               </div>
             ) : (
@@ -994,8 +994,8 @@ const SEPEPSportsHub: React.FC = () => {
                     <div key={yearLevel} className="space-y-6">
                       <div className="rounded-2xl border border-white/20 bg-white/80 p-8 shadow-xl">
                         <div className="mb-6 flex items-center justify-between">
-                          <h3 className="flex items-center text-2xl font-bold text-slate-800">
-                            <Medal className="mr-2 h-6 w-6 text-amber-600" />
+                          <h3 className="flex items-center text-2xl font-bold text-mbhs-navy">
+                            <Medal className="mr-2 h-6 w-6 text-mbhs-gold" />
                             {yearLevel} - Team Standings
                           </h3>
                           {sheets.isConnected && (
@@ -1011,13 +1011,13 @@ const SEPEPSportsHub: React.FC = () => {
                             <table className="w-full">
                               <thead>
                                 <tr className="border-b border-slate-200">
-                                  <th className="py-3 px-4 text-left font-semibold text-slate-800">Position</th>
-                                  <th className="py-3 px-4 text-left font-semibold text-slate-800">Team</th>
-                                  <th className="py-3 px-4 text-center font-semibold text-slate-800">W</th>
-                                  <th className="py-3 px-4 text-center font-semibold text-slate-800">D</th>
-                                  <th className="py-3 px-4 text-center font-semibold text-slate-800">L</th>
-                                  <th className="py-3 px-4 text-center font-semibold text-slate-800">TPSR</th>
-                                  <th className="py-3 px-4 text-right font-semibold text-slate-800">Points</th>
+                                  <th className="py-3 px-4 text-left font-semibold text-mbhs-navy">Position</th>
+                                  <th className="py-3 px-4 text-left font-semibold text-mbhs-navy">Team</th>
+                                  <th className="py-3 px-4 text-center font-semibold text-mbhs-navy">W</th>
+                                  <th className="py-3 px-4 text-center font-semibold text-mbhs-navy">D</th>
+                                  <th className="py-3 px-4 text-center font-semibold text-mbhs-navy">L</th>
+                                  <th className="py-3 px-4 text-center font-semibold text-mbhs-navy">TPSR</th>
+                                  <th className="py-3 px-4 text-right font-semibold text-mbhs-navy">Points</th>
                                 </tr>
                               </thead>
                               <tbody>
@@ -1028,18 +1028,18 @@ const SEPEPSportsHub: React.FC = () => {
                                     <tr key={team.team} className="border-b border-slate-100 transition-colors hover:bg-slate-50">
                                       <td className="py-4 px-4">
                                         <span className="flex items-center space-x-2">
-                                          <span className="font-bold text-slate-800">{index + 1}</span>
+                                          <span className="font-bold text-mbhs-navy">{index + 1}</span>
                                           {index === 0 && <span>🥇</span>}
                                           {index === 1 && <span>🥈</span>}
                                           {index === 2 && <span>🥉</span>}
                                         </span>
                                       </td>
-                                      <td className="py-4 px-4 font-semibold text-slate-800">{team.team}</td>
+                                      <td className="py-4 px-4 font-semibold text-mbhs-navy">{team.team}</td>
                                       <td className="py-4 px-4 text-center font-medium text-green-600">{team.wins}</td>
                                       <td className="py-4 px-4 text-center font-medium text-yellow-600">{team.draws}</td>
                                       <td className="py-4 px-4 text-center font-medium text-red-600">{team.losses}</td>
                                       <td className="py-4 px-4 text-center text-slate-600">{team.tpsr}</td>
-                                      <td className="py-4 px-4 text-right font-bold text-slate-800">{team.points}</td>
+                                      <td className="py-4 px-4 text-right font-bold text-mbhs-navy">{team.points}</td>
                                     </tr>
                                   ))}
                               </tbody>
@@ -1052,17 +1052,17 @@ const SEPEPSportsHub: React.FC = () => {
 
                       {data.matches && data.matches.length > 0 && (
                         <div className="rounded-2xl border border-white/20 bg-white/80 p-8 shadow-xl">
-                          <h3 className="mb-6 flex items-center text-2xl font-bold text-slate-800">
-                            <Target className="mr-2 h-6 w-6 text-blue-600" />
+                          <h3 className="mb-6 flex items-center text-2xl font-bold text-mbhs-navy">
+                            <Target className="mr-2 h-6 w-6 text-mbhs-blue" />
                             {yearLevel} - Recent Matches
                           </h3>
 
                           <div className="space-y-4">
                             {data.matches.slice(0, 10).map((match, idx) => (
-                              <div key={`${match.homeTeam}-${match.awayTeam}-${idx}`} className="rounded-xl border-l-4 border-blue-500 bg-slate-50 p-6">
+                              <div key={`${match.homeTeam}-${match.awayTeam}-${idx}`} className="rounded-xl border-l-4 border-mbhs-blue bg-slate-50 p-6">
                                 <div className="flex items-center justify-between">
                                   <div className="flex items-center space-x-4">
-                                    <span className="font-semibold text-slate-800">
+                                    <span className="font-semibold text-mbhs-navy">
                                       {match.homeTeam} vs {match.awayTeam}
                                     </span>
                                     {match.status === "Live" && (
@@ -1073,7 +1073,7 @@ const SEPEPSportsHub: React.FC = () => {
                                     )}
                                   </div>
                                   <div className="flex items-center space-x-2">
-                                    <span className="text-lg font-bold text-slate-800">{match.score}</span>
+                                    <span className="text-lg font-bold text-mbhs-navy">{match.score}</span>
                                     {match.round && <span className="text-sm text-slate-500">({match.round})</span>}
                                   </div>
                                 </div>
@@ -1093,26 +1093,26 @@ const SEPEPSportsHub: React.FC = () => {
         {activeSection === "teams" && (
           <div className="space-y-8">
             <div className="text-center">
-              <h2 className="mb-4 text-3xl font-bold text-slate-800">Team Information</h2>
+              <h2 className="mb-4 text-3xl font-bold text-mbhs-navy">Team Information</h2>
               <p className="text-slate-600">Team rosters and player lists</p>
             </div>
 
             {!sepepData.loaded ? (
               <div className="rounded-2xl border border-white/20 bg-white/80 p-8 text-center shadow-xl">
                 <Users className="mx-auto mb-4 h-16 w-16 text-slate-400" />
-                <h3 className="mb-2 text-xl font-semibold text-slate-800">No Team Data Available</h3>
+                <h3 className="mb-2 text-xl font-semibold text-mbhs-navy">No Team Data Available</h3>
                 <p className="text-slate-600">Load your SEPEP data to see team rosters.</p>
               </div>
             ) : (
               <div className="space-y-8">
                 {Object.entries(sepepData.teams).map(([yearLevel, teams]) => (
                   <div key={yearLevel} className="space-y-6">
-                    <h3 className="text-2xl font-bold text-slate-800">{yearLevel}</h3>
+                    <h3 className="text-2xl font-bold text-mbhs-navy">{yearLevel}</h3>
                     <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
                       {Object.entries(teams).map(([teamName, players]) => (
                         <div key={teamName} className="rounded-2xl border border-white/20 bg-white/80 p-6 shadow-xl">
-                          <h4 className="mb-4 flex items-center text-xl font-bold text-slate-800">
-                            <Users className="mr-2 h-5 w-5 text-blue-600" />
+                          <h4 className="mb-4 flex items-center text-xl font-bold text-mbhs-navy">
+                            <Users className="mr-2 h-5 w-5 text-mbhs-blue" />
                             {teamName}
                           </h4>
                           <p className="mb-3 text-sm font-medium text-slate-600">Players ({players.length})</p>
@@ -1130,12 +1130,12 @@ const SEPEPSportsHub: React.FC = () => {
                 ))}
 
                 {Object.keys(sepepData.teams).length === 0 && (
-                  <div className="rounded-xl border border-amber-200 bg-amber-50 p-6">
+                  <div className="rounded-xl border border-mbhs-gold/20 bg-mbhs-gold/10 p-6">
                     <div className="flex items-center space-x-3">
-                      <Users className="h-6 w-6 text-amber-600" />
+                      <Users className="h-6 w-6 text-mbhs-gold" />
                       <div>
-                        <h3 className="text-lg font-medium text-amber-800">Limited Team Data</h3>
-                        <p className="text-amber-700">Team roster information will appear after you connect your full Google Sheet.</p>
+                        <h3 className="text-lg font-medium text-mbhs-navy">Limited Team Data</h3>
+                        <p className="text-mbhs-navy/80">Team roster information will appear after you connect your full Google Sheet.</p>
                       </div>
                     </div>
                   </div>
@@ -1156,14 +1156,14 @@ const SEPEPSportsHub: React.FC = () => {
       />
 
       {/* Footer */}
-      <footer className="mt-16 bg-slate-800 text-white">
+      <footer className="mt-16 bg-mbhs-navy text-white">
         <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">
-              <Trophy className="h-6 w-6 text-amber-400" />
+              <Trophy className="h-6 w-6 text-mbhs-gold" />
               <div>
                 <h3 className="font-semibold">2024 Neighbourhood SEPEP</h3>
-                <p className="text-sm text-slate-400">
+                <p className="text-sm text-white/70">
                   Live Sports Hub {sheets.isConnected ? "with Google Sheets Integration" : "with Local Storage"}
                 </p>
               </div>
@@ -1185,8 +1185,8 @@ const SEPEPSportsHub: React.FC = () => {
       {loading && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/20 backdrop-blur-sm">
           <div className="flex items-center space-x-4 rounded-2xl bg-white p-8 shadow-2xl">
-            <RefreshCw className="h-6 w-6 animate-spin text-amber-600" />
-            <span className="font-medium text-slate-800">Processing your SEPEP data...</span>
+            <RefreshCw className="h-6 w-6 animate-spin text-mbhs-gold" />
+            <span className="font-medium text-mbhs-navy">Processing your SEPEP data...</span>
           </div>
         </div>
       )}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -4,7 +4,7 @@ export default function Card({title, right, children}:{title?:React.ReactNode; r
     <section className="card pad">
       {(title || right) && (
         <header className="flex items-center justify-between mb-4">
-          {title ? <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100">{title}</h3> : <div/>}
+          {title ? <h3 className="text-lg font-semibold text-mbhs-navy">{title}</h3> : <div/>}
           {right}
         </header>
       )}

--- a/src/components/ui/Ladder.tsx
+++ b/src/components/ui/Ladder.tsx
@@ -1,21 +1,21 @@
 export default function Ladder({houses}:{houses:Record<string,number>}) {
   const sorted = Object.entries(houses).sort(([,a],[,b])=>Number(b)-Number(a));
   const color = (name:string) => {
-    if (/pondi/i.test(name)) return 'bg-house-red/10 text-house-red';
-    if (/kungari/i.test(name)) return 'bg-house-green/10 text-house-green';
-    if (/wirakuthi/i.test(name)) return 'bg-house-blue/10 text-house-blue';
-    if (/no:ri/i.test(name)) return 'bg-house-yellow/10 text-house-yellow';
+    if (/kungari/i.test(name)) return 'bg-hood-kungari/10 text-hood-kungari';
+    if (/no:ri/i.test(name)) return 'bg-hood-nori/10 text-hood-nori';
+    if (/pondi/i.test(name)) return 'bg-hood-pondi/10 text-hood-pondi';
+    if (/wirakuthi/i.test(name)) return 'bg-hood-wirakuthi/10 text-hood-wirakuthi';
     return 'bg-slate-100 text-slate-700';
   };
   return (
     <div className="space-y-3">
       {sorted.map(([name,score],i)=>(
-        <div key={name} className="flex items-center justify-between bg-white odd:bg-slate-50 dark:bg-slate-800/60 dark:odd:bg-slate-800/40 rounded-xl p-3">
+        <div key={name} className="flex items-center justify-between bg-white odd:bg-slate-50 rounded-xl p-3">
           <div className="flex items-center gap-3">
-            <span className="text-sm font-semibold text-slate-500 w-6 text-right">{i+1}</span>
+            <span className="text-sm font-semibold text-mbhs-navy/70 w-6 text-right">{i+1}</span>
             <span className={`px-2 py-1 rounded ${color(name)} font-medium`}>{name}</span>
           </div>
-          <span className="font-bold text-slate-900 text-right">{score}</span>
+          <span className="font-bold text-mbhs-navy text-right">{score}</span>
         </div>
       ))}
       {!sorted.length && <p className="text-slate-600">No data yet.</p>}

--- a/src/components/ui/Stat.tsx
+++ b/src/components/ui/Stat.tsx
@@ -4,8 +4,8 @@ export default function Stat({label, value, icon}:{label:string; value:React.Rea
     <div className="card p-6">
       <div className="flex items-center justify-between">
         <div>
-          <p className="text-sm font-medium text-slate-600">{label}</p>
-          <p className="text-3xl font-bold text-slate-800">{value}</p>
+          <p className="text-sm font-medium text-mbhs-navy/70">{label}</p>
+          <p className="text-3xl font-bold text-mbhs-navy">{value}</p>
         </div>
         {icon}
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -5,13 +5,13 @@
 :root { color-scheme: light dark; }
 html, body { @apply antialiased; }
 html, body, #root { height: 100%; }
-.btn { @apply inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2 font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2; }
-.btn-primary { @apply bg-slate-900 text-white hover:bg-slate-800 focus-visible:ring-slate-900; }
-.btn-accent  { @apply bg-accent-500 text-slate-900 hover:bg-accent-600 focus-visible:ring-accent-600; }
-.btn-ghost   { @apply ring-1 ring-slate-300 bg-white text-slate-800 hover:bg-slate-50; }
-.card  { @apply rounded-2xl border border-white/20 bg-white/80 dark:bg-slate-900/60 shadow-card; }
-.h1 { @apply text-3xl sm:text-4xl font-extrabold text-slate-900 dark:text-white leading-tight }
-.h2 { @apply text-2xl font-bold text-slate-800 dark:text-slate-100 }
+.card { @apply rounded-2xl border border-slate-200/60 bg-white shadow-card; }
+.btn  { @apply inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2 font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2; }
+.btn-primary { @apply bg-mbhs-navy text-white hover:bg-slate-800 focus-visible:ring-mbhs-navy; }
+.btn-accent  { @apply bg-mbhs-gold text-white hover:bg-amber-600 focus-visible:ring-amber-600; }
+.btn-ghost   { @apply ring-1 ring-slate-300 bg-white text-slate-900 hover:bg-slate-50; }
+.h1 { @apply text-3xl sm:text-4xl font-extrabold text-mbhs-navy leading-tight }
+.h2 { @apply text-2xl font-bold text-mbhs-navy }
 .muted { @apply text-xs text-slate-500 }
 /* 8-pt rhythm helpers (optional) */
 .pad { @apply p-6 sm:p-8 } .gap { @apply gap-6 } .gap-lg { @apply gap-8 }

--- a/src/pages/Student.tsx
+++ b/src/pages/Student.tsx
@@ -44,12 +44,12 @@ function StudentApp() {
   const latest = toResults(rows).slice(0, 10);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-blue-50 to-green-50">
+    <div className="min-h-screen bg-gradient-to-br from-mbhs-white via-slate-50 to-mbhs-white">
       <div role="status" aria-live="polite" className="sr-only" id="a11y-updates" />
-      <header className="bg-white/80 backdrop-blur-lg border-b border-white/20 sticky top-0 z-40">
+      <header className="bg-mbhs-navy text-white sticky top-0 z-40">
         <div className="max-w-6xl mx-auto pad flex items-center justify-between">
-          <h1 className="h1">SEPEP Student Hub</h1>
-          <div className="muted">Last update: {lastUpdated || '—'}</div>
+          <h1 className="text-2xl font-bold">SEPEP Student Hub</h1>
+          <div className="muted text-white/80">Last update: {lastUpdated || '—'}</div>
         </div>
       </header>
 
@@ -63,12 +63,12 @@ function StudentApp() {
         <Card title="Latest Matches">
           <div className="space-y-3">
             {latest.map((m,i)=>(
-              <div key={i} className="flex items-center justify-between bg-white odd:bg-slate-50 dark:bg-slate-800/60 dark:odd:bg-slate-800/40 rounded-lg p-3">
-                <span className="text-slate-800 font-medium">{m.homeTeam} vs {m.awayTeam}</span>
-                <span className="font-bold text-slate-900 text-right">{m.score}</span>
+              <div key={i} className="flex items-center justify-between bg-white odd:bg-slate-50 rounded-lg p-3">
+                <span className="text-mbhs-navy font-medium">{m.homeTeam} vs {m.awayTeam}</span>
+                <span className="font-bold text-mbhs-navy text-right">{m.score}</span>
               </div>
             ))}
-            {!latest.length && <p className="text-slate-600">No recent results yet.</p>}
+            {!latest.length && <p className="text-mbhs-navy/70">No recent results yet.</p>}
           </div>
         </Card>
       </main>

--- a/src/pages/Teacher.tsx
+++ b/src/pages/Teacher.tsx
@@ -18,12 +18,12 @@ function TeacherApp(){
   }, []);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-blue-50 to-green-50">
+    <div className="min-h-screen bg-gradient-to-br from-mbhs-white via-slate-50 to-mbhs-white">
       <div role="status" aria-live="polite" className="sr-only" id="a11y-updates" />
-      <header className="bg-white/80 backdrop-blur-lg border-b border-white/20 sticky top-0 z-40">
+      <header className="bg-mbhs-navy text-white sticky top-0 z-40">
         <div className="max-w-6xl mx-auto pad flex items-center justify-between">
-          <h1 className="h1">SEPEP Teacher</h1>
-          <div className="muted truncate max-w-[60%]">API: {apiUrl || 'not set (see sepep.config.json)'}</div>
+          <h1 className="text-2xl font-bold">SEPEP Teacher</h1>
+          <div className="muted truncate max-w-[60%] text-white/80">API: {apiUrl || 'not set (see sepep.config.json)'}</div>
         </div>
       </header>
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,18 +1,36 @@
 import type { Config } from 'tailwindcss';
 
 export default {
-  content: ["./index.html", "./**/*.html", "./src/**/*.{ts,tsx,js}"],
+  content: ["./index.html", "./**/*.html", "./src/**/*.{ts,tsx,js,jsx,html}"],
   theme: {
     extend: {
       colors: {
-        brand: { 50:"#eef2ff",100:"#e0e7ff",400:"#6366f1",600:"#4f46e5",800:"#3730a3" },
-        brandBase: "#2563eb",
-        accent:{ 50:"#fff7ed",100:"#ffedd5",500:"#f59e0b",600:"#d97706" },
-        success:"#16a34a", warning:"#f59e0b", danger:"#dc2626",
-        house: { blue:"#2563eb", red:"#dc2626", green:"#16a34a", yellow:"#ca8a04" }
+        mbhs: {
+          navy: "#0F172A",
+          blue: "#2563EB",
+          gold: "#F59E0B",
+          white: "#FFFFFF",
+        },
+        // Neighbourhood / data colours
+        hood: {
+          kungari: "#2563EB",
+          nori: "#16A34A",
+          pondi: "#CA8A04",
+          wirakuthi: "#DC2626",
+        },
+        // (Temporary alias to avoid breakage if code still uses "house")
+        house: {
+          blue: "#2563EB",
+          green: "#16A34A",
+          yellow: "#CA8A04",
+          red: "#DC2626",
+        },
+        success: "#16A34A",
+        warning: "#F59E0B",
+        danger: "#DC2626",
       },
-      borderRadius: { xl:"1rem", '2xl':"1.25rem" },
-      boxShadow: { card:"0 8px 30px rgb(2 8 23 / 0.06)" }
+      boxShadow: { card: "0 8px 30px rgb(2 8 23 / 0.08)" },
+      borderRadius: { '2xl': "1.25rem" },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- apply Murray Bridge HS colour tokens and global utilities
- restyle header/nav, buttons, tabs and cards with MBHS navy & gold
- show neighbourhood colours for ladder chips and data elements

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c5450bfee0832781cd1ae0f62acc10