### PR TITLE
Add Vitest test runner and sample test

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The Admin page includes tools to export current results as JSON and import fixtu
 Use the top bar toggle to switch Teacher Mode on/off. The state persists in `localStorage` and will be used to gate admin-only actions.
 
 ## Testing
+This project uses [Vitest](https://vitest.dev) for unit tests. Run them with:
 
 ```bash
 npm test

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -21,6 +22,7 @@
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.2.2",
-    "vite": "^5.1.0"
+    "vite": "^5.1.0",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/sample.test.ts
+++ b/src/sample.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('adds numbers correctly', () => {
+    expect(1 + 1).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest and `npm test` script
- document testing with Vitest in README
- include a simple sample test

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c7a5e2a0b08327a3d9e31e5828ad05