### PR TITLE
Add Vitest setup and sample test

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,5 @@ Use the top bar toggle to switch Teacher Mode on/off. The state persists in `loc
 ```bash
 npm test
 ```
+
+Runs the [Vitest](https://vitest.dev) test runner.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -21,6 +22,7 @@
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.2.2",
-    "vite": "^5.1.0"
+    "vite": "^5.1.0",
+    "vitest": "^1.0.0"
   }
 }

--- a/src/sample.test.ts
+++ b/src/sample.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('math', () => {
+  it('adds numbers', () => {
+    expect(1 + 1).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest test runner and script
- include example test under src
- document how to run tests in README

## Testing
- `npm install --save-dev vitest` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c7a619244483279c42384a193a20af