### PR TITLE
Add runtime validation and error handling

### DIFF
--- a/src/SEPEPSportsHub.tsx
+++ b/src/SEPEPSportsHub.tsx
@@ -92,8 +92,8 @@ const SEPEPSportsHub: React.FC = () => {
           savedAt: new Date().toISOString(),
         })
       );
-    } catch {
-      // ignore
+    } catch (e) {
+      console.error("Failed to save data", e);
     }
   }, []);
 
@@ -101,8 +101,8 @@ const SEPEPSportsHub: React.FC = () => {
     try {
       const saved = localStorage.getItem("sepep_data");
       if (saved) return JSON.parse(saved) as SepepData;
-    } catch {
-      // ignore
+    } catch (e) {
+      console.error("Failed to load saved data", e);
     }
     return null;
   }, []);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,10 +5,62 @@ const getBase = () => {
   return base ? base + '/exec' : '';
 };
 
-export async function fetchSummary() {
+export type SummaryRow = {
+  YearLevel?: string;
+  HomeTeam?: string;
+  AwayTeam?: string;
+  HomeScore?: number | string;
+  AwayScore?: number | string;
+  Round?: string;
+  Status?: string;
+};
+
+export type SummaryData = { houses: Record<string, number>; rows: SummaryRow[] };
+
+function validateSummary(data: any): SummaryData {
+  if (!data || typeof data !== 'object') throw new Error('Invalid API response');
+
+  const houses: Record<string, number> = {};
+  if (data.houses && typeof data.houses === 'object') {
+    for (const [k, v] of Object.entries(data.houses)) {
+      if (typeof v === 'number') houses[k] = v;
+    }
+  }
+
+  let rows: SummaryRow[] = [];
+  if (Array.isArray(data.rows)) {
+    rows = data.rows
+      .filter((r: any) => r && typeof r === 'object')
+      .map((r: any) => ({
+        YearLevel: typeof r.YearLevel === 'string' ? r.YearLevel : undefined,
+        HomeTeam: typeof r.HomeTeam === 'string' ? r.HomeTeam : undefined,
+        AwayTeam: typeof r.AwayTeam === 'string' ? r.AwayTeam : undefined,
+        HomeScore:
+          typeof r.HomeScore === 'number' || typeof r.HomeScore === 'string'
+            ? r.HomeScore
+            : undefined,
+        AwayScore:
+          typeof r.AwayScore === 'number' || typeof r.AwayScore === 'string'
+            ? r.AwayScore
+            : undefined,
+        Round: typeof r.Round === 'string' ? r.Round : undefined,
+        Status: typeof r.Status === 'string' ? r.Status : undefined,
+      }));
+  }
+
+  return { houses, rows };
+}
+
+export async function fetchSummary(): Promise<SummaryData> {
   const base = getBase();
   if (!base) throw new Error('Missing SEPEP API URL');
   const r = await fetch(`${base}?action=summary`, { cache: 'no-store' });
   if (!r.ok) throw new Error(`API ${r.status}`);
-  return r.json();
+  try {
+    const data = await r.json();
+    return validateSummary(data);
+  } catch (e) {
+    console.error('Invalid API response', e);
+    throw e;
+  }
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,9 +1,24 @@
 export type SepepConfig = { apiUrl?: string; staffFormUrl?: string };
+
+function validateConfig(data: any): SepepConfig {
+  if (data && typeof data === 'object') {
+    const cfg: SepepConfig = {};
+    if (typeof data.apiUrl === 'string') cfg.apiUrl = data.apiUrl;
+    if (typeof data.staffFormUrl === 'string') cfg.staffFormUrl = data.staffFormUrl;
+    return cfg;
+  }
+  throw new Error('Invalid config format');
+}
+
 export async function loadConfig(): Promise<SepepConfig> {
+  const url = ((import.meta as any).env?.BASE_URL || '/') + 'sepep.config.json';
   try {
-    const url = ((import.meta as any).env?.BASE_URL || '/') + 'sepep.config.json';
     const r = await fetch(url, { cache: 'no-store' });
-    if (r.ok) return r.json();
-  } catch {}
-  return {};
+    if (!r.ok) throw new Error(`Config ${r.status}`);
+    const data = await r.json();
+    return validateConfig(data);
+  } catch (e) {
+    console.error('Failed to load config', e);
+    throw e;
+  }
 }

--- a/src/pages/Student.tsx
+++ b/src/pages/Student.tsx
@@ -23,18 +23,24 @@ function StudentApp() {
 
   useEffect(() => {
     (async () => {
-      const cfg = await loadConfig();
-      if (cfg.apiUrl) localStorage.setItem('sepep_api_url', cfg.apiUrl);
+      try {
+        const cfg = await loadConfig();
+        if (cfg.apiUrl) localStorage.setItem('sepep_api_url', cfg.apiUrl);
+      } catch (e) {
+        console.error(e);
+        setError('Failed to load configuration');
+      }
       const tick = async () => {
         try {
           const data = await fetchSummary();
-          setHouses(data.houses || {});
-          setRows(data.rows || []);
+          setHouses(data.houses);
+          setRows(data.rows);
           setLastUpdated(new Date().toLocaleString());
           setLiveMessage(`Scores updated ${new Date().toLocaleTimeString()}`);
           setError('');
-        } catch (e:any) {
-          setError('Missing or invalid API URL (see sepep.config.json)');
+        } catch (e: any) {
+          console.error(e);
+          setError(e.message || 'Failed to fetch scores');
         }
       };
       await tick();

--- a/src/pages/Teacher.tsx
+++ b/src/pages/Teacher.tsx
@@ -9,13 +9,19 @@ function TeacherApp(){
   const [formUrl, setFormUrl] = useState<string>('');
   const [apiUrl, setApiUrl] = useState<string>('');
   const [liveMessage, setLiveMessage] = useState<string>('');
+  const [error, setError] = useState<string>('');
 
   useEffect(() => {
     (async () => {
-      const cfg = await loadConfig();
-      if (cfg.apiUrl) { localStorage.setItem('sepep_api_url', cfg.apiUrl); setApiUrl(cfg.apiUrl); }
-      if (cfg.staffFormUrl) setFormUrl(cfg.staffFormUrl);
-      setLiveMessage(`Scores updated ${new Date().toLocaleTimeString()}`);
+      try {
+        const cfg = await loadConfig();
+        if (cfg.apiUrl) { localStorage.setItem('sepep_api_url', cfg.apiUrl); setApiUrl(cfg.apiUrl); }
+        if (cfg.staffFormUrl) setFormUrl(cfg.staffFormUrl);
+        setLiveMessage(`Scores updated ${new Date().toLocaleTimeString()}`);
+      } catch (e) {
+        console.error(e);
+        setError('Failed to load configuration');
+      }
     })();
   }, []);
 
@@ -30,6 +36,7 @@ function TeacherApp(){
       </header>
 
       <main className="max-w-6xl mx-auto pad space-y-4">
+        {error && <div className="card pad text-danger bg-danger/10 border-danger/20">{error}</div>}
         {formUrl ? (
           <Card title="Staff Results Form">
             <iframe title="SEPEP Staff Form" src={formUrl} className="w-full h-[80vh] rounded-lg" />


### PR DESCRIPTION
## Summary
- Validate config file and propagate load errors
- Add runtime checks for API summary data
- Handle config/API validation issues in student, teacher, and sports hub pages

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c7aa8de1288327b004de2a4955f12c