### PR TITLE
Add Add Team page and Apps Script endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 VITE_SEPEP_API_URL=        # optional; runtime config file will override
+VITE_API_BASE=
 VITE_POLL_MS=15000

--- a/README.md
+++ b/README.md
@@ -38,6 +38,27 @@ VITE_SEPEP_API_URL=https://script.google.com/macros/s/APP_SCRIPT_ID/exec
 
 If unset, the application falls back to a placeholder URL or the `apiUrl` value in `public/sepep.config.json`. See `.env.example` for a template.
 
+The Add Team page posts to a separate Apps Script endpoint configured via `VITE_API_BASE`:
+
+```bash
+VITE_API_BASE=https://script.google.com/macros/s/DEPLOYMENT_ID/exec
+```
+
+After updating `.env`, rebuild and redeploy to update the GitHub Pages site.
+
+## Add Team API (Apps Script)
+
+`apps-script/Code.gs` contains a sheet-bound Apps Script that appends team rows. Deploy it as a Web App:
+
+1. In the Script editor choose **Deploy → New deployment → Web app**.
+2. **Execute as:** Me.
+3. **Who has access:** Anyone with the link.
+4. Copy the `/exec` URL and set `VITE_API_BASE`.
+
+When you edit the script later, use **Deploy → Manage deployments** and either create a new deployment or edit the existing one to point at the latest head version.
+
+Apps Script web apps must return a `ContentService` or HTML payload. The script uses `ContentService.createTextOutput(JSON.stringify(payload)).setMimeType(ContentService.MimeType.JSON)` so `fetch` can parse the JSON response. Handlers `doGet(e)` and `doPost(e)` receive query-string parameters via the `e.parameter` object.
+
 ## Data schema
 
 Sample JSON files live in `public/data`:

--- a/apps-script/Code.gs
+++ b/apps-script/Code.gs
@@ -1,0 +1,59 @@
+// Google Apps Script (Code.gs)
+const SHEET_ID = '1qF5UKJtUNVSoAaBcM1WiIaSclZzgct8oUkfV73FSF_I';
+
+function doPost(e) {
+  const endpoint = e && e.parameter && e.parameter.endpoint;
+  if (endpoint !== 'addTeam') return _json({ ok:false, error: 'Unknown endpoint' }, 400);
+
+  try {
+    const body = e.postData && e.postData.contents ? JSON.parse(e.postData.contents) : {};
+    const { teamId = '', teamName = '', neighbourhood = '', division = '' } = body;
+
+    // Basic validation
+    if (!teamId || !teamName) return _json({ ok:false, error:'teamId and teamName are required' }, 400);
+
+    const ss = SpreadsheetApp.openById(SHEET_ID);
+    let sh = ss.getSheetByName('Teams');
+    if (!sh) {
+      sh = ss.insertSheet('Teams');
+      sh.appendRow(['teamId','teamName','neighbourhood','division']);
+    }
+
+    sh.appendRow([teamId, teamName, neighbourhood, division]);
+    return _json({ ok: true });
+  } catch (err) {
+    return _json({ ok:false, error: String(err) }, 500);
+  }
+}
+
+function doGet(e) {
+  const endpoint = e && e.parameter && e.parameter.endpoint;
+  const ss = SpreadsheetApp.openById(SHEET_ID);
+
+  if (endpoint === 'teams') {
+    const sh = ss.getSheetByName('Teams');
+    return _json(_sheetToObjects(sh));
+  }
+  if (endpoint === 'results') {
+    const sh = ss.getSheetByName('Results');
+    return _json(_sheetToObjects(sh));
+  }
+  return _json({ ok:false, error:'Unknown endpoint' }, 400);
+}
+
+function _sheetToObjects(sh) {
+  if (!sh) return [];
+  const values = sh.getDataRange().getDisplayValues();
+  if (values.length < 2) return [];
+  const headers = values.shift();
+  return values
+    .filter(r => r.join('').trim() !== '')
+    .map(row => Object.fromEntries(headers.map((h,i)=>[h,row[i]])));
+}
+
+function _json(payload, statusCodeIgnored) {
+  // ContentService JSON is valid for Apps Script web apps.
+  return ContentService.createTextOutput(JSON.stringify(payload))
+    .setMimeType(ContentService.MimeType.JSON);
+}
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,18 @@
+import SEPEPSportsHub from "./SEPEPSportsHub";
+import AddTeam from "./pages/AddTeam";
+
+export default function App() {
+  const path = typeof window !== "undefined" ? window.location.pathname : "/";
+  const showAddTeam = path.endsWith("/add-team");
+  const base = (import.meta as any).env?.BASE_URL || "/";
+  return (
+    <div>
+      <nav className="p-4 bg-slate-100 flex gap-4">
+        <a href={base} className="text-blue-600 hover:underline">Home</a>
+        <a href={`${base}add-team`} className="text-blue-600 hover:underline">Add Team</a>
+      </nav>
+      {showAddTeam ? <AddTeam /> : <SEPEPSportsHub />}
+    </div>
+  );
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import './index.css'
-import SEPEPSportsHub from './SEPEPSportsHub'
+import App from './App'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <SEPEPSportsHub />
+    <App />
   </React.StrictMode>,
 )

--- a/src/pages/AddTeam.tsx
+++ b/src/pages/AddTeam.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+
+const API_BASE = import.meta.env.VITE_API_BASE; // e.g., https://script.google.com/macros/s/.../exec
+
+export default function AddTeam() {
+  const [form, setForm] = useState({ teamId:"", teamName:"", neighbourhood:"", division:"" });
+  const [loading, setLoading] = useState(false);
+  const [msg, setMsg] = useState<{ok:boolean; text:string} | null>(null);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setMsg(null);
+    try {
+      const res = await fetch(`${API_BASE}?endpoint=addTeam`, {
+        method: "POST",
+        headers: { "Content-Type":"application/json" },
+        body: JSON.stringify(form),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.ok) throw new Error(data.error || "Failed to add team");
+      setMsg({ ok:true, text:"Team added!" });
+      setForm({ teamId:"", teamName:"", neighbourhood:"", division:"" });
+    } catch (err:any) {
+      setMsg({ ok:false, text: err.message || "Error adding team" });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function Field({name,label,required=false}:{name:keyof typeof form;label:string;required?:boolean}) {
+    return (
+      <label className="grid gap-1">
+        <span className="text-sm text-gray-600">{label}</span>
+        <input
+          className="border rounded p-2"
+          required={required}
+          value={form[name]}
+          onChange={e=>setForm({...form, [name]: e.target.value})}
+        />
+      </label>
+    );
+  }
+
+  return (
+    <div className="p-6 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Add Team</h1>
+      <form onSubmit={onSubmit} className="grid gap-3">
+        <Field name="teamId" label="Team ID (short code)" required />
+        <Field name="teamName" label="Team Name" required />
+        <Field name="neighbourhood" label="Neighbourhood" />
+        <Field name="division" label="Division (e.g., Year 7)" />
+        <button disabled={loading} className="rounded bg-blue-600 text-white px-4 py-2 disabled:opacity-50">
+          {loading ? "Saving…" : "Add Team"}
+        </button>
+      </form>
+      {msg && <p className={`mt-3 ${msg.ok ? "text-green-600" : "text-red-600"}`}>{msg.text}</p>}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Google Apps Script sample that appends rows to Teams sheet
- expose Add Team React page and wire route
- document Apps Script deployment and API base env variable

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c7c7dca3fc83279b17d56b1f062a1f