### PR TITLE
Improve latest results layout responsiveness

### DIFF
--- a/src/pages/Student.tsx
+++ b/src/pages/Student.tsx
@@ -71,9 +71,12 @@ function StudentApp() {
         <Card title="Latest Matches">
           <div className="space-y-3">
             {latest.map((m,i)=>(
-              <div key={i} className="flex items-center justify-between bg-white odd:bg-slate-50 rounded-lg p-3">
-                <span className="text-mbhs-navy font-medium">{m.homeTeam} vs {m.awayTeam}</span>
-                <span className="font-bold text-mbhs-navy text-right">{m.score}</span>
+              <div
+                key={i}
+                className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-1 sm:gap-0 bg-white odd:bg-slate-50 rounded-lg p-3"
+              >
+                <span className="text-mbhs-navy font-medium break-words">{m.homeTeam} vs {m.awayTeam}</span>
+                <span className="font-bold text-mbhs-navy text-left sm:text-right">{m.score}</span>
               </div>
             ))}
             {!latest.length && <p className="text-mbhs-navy/70">No recent results yet.</p>}


### PR DESCRIPTION
## Summary
- Make latest match rows responsive with mobile-first layout
- Align score text left on mobile and right on desktop
- Allow long team names to wrap without overflowing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c7e30abb3c8327a3e2c1a03419c732