### PR TITLE
Refactor Student polling effect for proper interval cleanup

### DIFF
--- a/src/pages/Student.tsx
+++ b/src/pages/Student.tsx
@@ -21,6 +21,20 @@ function StudentApp() {
     .filter(r => r.HomeTeam && r.AwayTeam)
     .map(r => ({ homeTeam: r.HomeTeam, awayTeam: r.AwayTeam, score: `${r.HomeScore}-${r.AwayScore}`, round: r.Round || 'Latest', status: r.Status || 'Final' }));
 
+  const tick = async () => {
+    try {
+      const data = await fetchSummary();
+      setHouses(data.houses);
+      setRows(data.rows);
+      setLastUpdated(new Date().toLocaleString());
+      setLiveMessage(`Scores updated ${new Date().toLocaleTimeString()}`);
+      setError('');
+    } catch (e: any) {
+      console.error(e);
+      setError(e.message || 'Failed to fetch scores');
+    }
+  };
+
   useEffect(() => {
     (async () => {
       try {
@@ -30,23 +44,11 @@ function StudentApp() {
         console.error(e);
         setError('Failed to load configuration');
       }
-      const tick = async () => {
-        try {
-          const data = await fetchSummary();
-          setHouses(data.houses);
-          setRows(data.rows);
-          setLastUpdated(new Date().toLocaleString());
-          setLiveMessage(`Scores updated ${new Date().toLocaleTimeString()}`);
-          setError('');
-        } catch (e: any) {
-          console.error(e);
-          setError(e.message || 'Failed to fetch scores');
-        }
-      };
-      await tick();
-      const id = setInterval(tick, Number((import.meta as any).env?.VITE_POLL_MS ?? 15000));
-      return () => clearInterval(id);
     })();
+
+    tick();
+    const id = setInterval(tick, Number((import.meta as any).env?.VITE_POLL_MS ?? 15000));
+    return () => clearInterval(id);
   }, []);
 
   const latest = toResults(rows).slice(0, 10);


### PR DESCRIPTION
## Summary
- Refactor Student page polling logic to define `tick` outside `useEffect` and register interval with direct cleanup.

## Testing
- `npx vitest run`
- `npm run build` *(fails: Property 'env' does not exist on type 'ImportMeta' in src/pages/AddTeam.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68c7e3f040508327be6f60794498d60f