### PR TITLE
Handle missing scores gracefully in student view

### DIFF
--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { formatScore } from './format';
+
+describe('formatScore', () => {
+  it('formats valid scores', () => {
+    expect(formatScore(1, 2)).toBe('1-2');
+  });
+
+  it('handles missing scores', () => {
+    expect(formatScore(undefined, 2)).toBe('TBD');
+    expect(formatScore(1, undefined)).toBe('TBD');
+    expect(formatScore(undefined, undefined)).toBe('TBD');
+  });
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,5 @@
+export function formatScore(home?: number | string, away?: number | string): string {
+  const hasHome = home !== undefined && home !== null && home !== '';
+  const hasAway = away !== undefined && away !== null && away !== '';
+  return hasHome && hasAway ? `${home}-${away}` : 'TBD';
+}

--- a/src/pages/Student.tsx
+++ b/src/pages/Student.tsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom/client';
 import '../index.css';
 import { loadConfig } from '../lib/config';
 import { fetchSummary } from '../lib/api';
+import { formatScore } from '../lib/format';
 import Card from '../components/ui/Card';
 import Ladder from '../components/ui/Ladder';
 
@@ -17,9 +18,16 @@ function StudentApp() {
   const [error, setError] = useState<string>('');
   const [liveMessage, setLiveMessage] = useState<string>('');
 
-  const toResults = (rws: Row[] = []) => rws
-    .filter(r => r.HomeTeam && r.AwayTeam)
-    .map(r => ({ homeTeam: r.HomeTeam, awayTeam: r.AwayTeam, score: `${r.HomeScore}-${r.AwayScore}`, round: r.Round || 'Latest', status: r.Status || 'Final' }));
+  const toResults = (rws: Row[] = []) =>
+    rws
+      .filter(r => r.HomeTeam && r.AwayTeam)
+      .map(r => ({
+        homeTeam: r.HomeTeam,
+        awayTeam: r.AwayTeam,
+        score: formatScore(r.HomeScore, r.AwayScore),
+        round: r.Round || 'Latest',
+        status: r.Status || 'Final',
+      }));
 
   useEffect(() => {
     (async () => {


### PR DESCRIPTION
## Summary
- Avoid displaying `undefined-undefined` for incomplete match scores
- Add shared `formatScore` helper with unit tests

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c816b433b4832796eec5a0c5a0e686