### PR TITLE
Configure Pages deploy to use SEPEP API env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,19 +21,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Use Node.js
+      - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: npm
+          cache: 'npm'
 
-      - name: Install dependencies
+      - name: Install deps
         run: npm ci
 
-      - name: Set Vite environment variables
+      - name: Inject Vite env (from secrets)
         run: |
+          if [ -z "${{ secrets.VITE_SEPEP_API_URL }}" ]; then
+            echo "❌ Missing Actions secret: VITE_SEPEP_API_URL" && exit 1
+          fi
           echo "VITE_SEPEP_API_URL=${{ secrets.VITE_SEPEP_API_URL }}" >> $GITHUB_ENV
           echo "VITE_POLLING_ENABLED=false" >> $GITHUB_ENV
+          echo "✅ Exported VITE_SEPEP_API_URL to build env"
+
+      - name: Show env (redacted)
+        run: |
+          echo "VITE_SEPEP_API_URL length: ${#VITE_SEPEP_API_URL}"
+          echo "VITE_POLLING_ENABLED: $VITE_POLLING_ENABLED"
 
       - name: Build
         run: npm run build
@@ -50,6 +59,6 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Deploy to GitHub Pages
+      - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v4

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,9 @@ import ReactDOM from 'react-dom/client'
 import './index.css'
 import App from './App'
 
+// eslint-disable-next-line no-console
+console.log('VITE_SEPEP_API_URL present?', Boolean(import.meta.env.VITE_SEPEP_API_URL))
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />

--- a/src/pages/Neighbourhoods.tsx
+++ b/src/pages/Neighbourhoods.tsx
@@ -2,7 +2,7 @@ import { RefreshCcw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import Card from '../components/ui/Card';
-import usePollingFetch from '../hooks/usePollingFetch';
+import usePollingFetch from '../lib/usePollingFetch';
 import { getNeighbourhoods, hasRemoteApi } from '../lib/api';
 
 type NeighbourhoodRow = {


### PR DESCRIPTION
## Summary
- replace the Pages deployment workflow to export the VITE_SEPEP_API_URL secret and log redacted diagnostics before building
- log whether the VITE_SEPEP_API_URL value was bundled at app start for easier runtime verification
- point the neighbourhoods page at the shared polling hook so the build succeeds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68c9f95b2bdc8327984b5bb47326c425